### PR TITLE
Amls 2114

### DIFF
--- a/app/models/des/businessactivities/BusinessActivitiesAll.scala
+++ b/app/models/des/businessactivities/BusinessActivitiesAll.scala
@@ -36,7 +36,7 @@ case class BusinessActivitiesAll(
                                   suspiciousActivityGuidance: Boolean,
                                   nationalCrimeAgencyRegistered: Boolean,
                                   formalRiskAssessmentDetails: Option[FormalRiskAssessmentDetails],
-                                  mlrAdvisor: MlrAdvisor)
+                                  mlrAdvisor: Option[MlrAdvisor])
 
 object BusinessActivitiesAll{
 

--- a/app/models/des/businessactivities/MlrAdvisor.scala
+++ b/app/models/des/businessactivities/MlrAdvisor.scala
@@ -51,8 +51,9 @@ object MlrAdvisor {
   implicit def convert(bact: models.fe.businessactivities.BusinessActivities): Option[MlrAdvisor] = {
     bact.accountantForAMLSRegulations match {
       case Some(x) => Some(MlrAdvisor(x.accountantForAMLSRegulations, bact))
-      case _ if (!AmlsConfig.release7) => Some(MlrAdvisor(false))
-      case _ => None
+        // have to keep sending for now as is required in API4 - a defect has been raised
+      case _  => Some(MlrAdvisor(false))
+
     }
   }
 }

--- a/app/models/des/businessactivities/MlrAdvisor.scala
+++ b/app/models/des/businessactivities/MlrAdvisor.scala
@@ -16,6 +16,7 @@
 
 package models.des.businessactivities
 
+import config.AmlsConfig
 import models.fe.businessactivities.WhoIsYourAccountant
 import play.api.libs.json.Json
 
@@ -23,7 +24,7 @@ case class MlrAdvisorDetails(advisorNameAddress: Option[AdvisorNameAddress],
                              agentDealsWithHmrc: Boolean,
                              hmrcAgentRefNo: Option[String])
 
-object MlrAdvisorDetails{
+object MlrAdvisorDetails {
   implicit val format = Json.format[MlrAdvisorDetails]
 
   implicit def convert(ba: models.fe.businessactivities.BusinessActivities): Option[MlrAdvisorDetails] = {
@@ -33,7 +34,7 @@ object MlrAdvisorDetails{
     }
   }
 
-  implicit def dealsWithTaxConvert(accountant:Option[WhoIsYourAccountant]): Option[AdvisorNameAddress] ={
+  implicit def dealsWithTaxConvert(accountant: Option[WhoIsYourAccountant]): Option[AdvisorNameAddress] = {
     accountant match {
       case Some(data) => data
       case None => None
@@ -44,13 +45,14 @@ object MlrAdvisorDetails{
 case class MlrAdvisor(doYouHaveMlrAdvisor: Boolean,
                       mlrAdvisorDetails: Option[MlrAdvisorDetails] = None)
 
-object MlrAdvisor{
+object MlrAdvisor {
   implicit val format = Json.format[MlrAdvisor]
 
-  implicit def convert(bact: models.fe.businessactivities.BusinessActivities): MlrAdvisor ={
-    bact.accountantForAMLSRegulations match{
-      case Some(x) => MlrAdvisor(x.accountantForAMLSRegulations, bact)
-      case _ => MlrAdvisor(false)
+  implicit def convert(bact: models.fe.businessactivities.BusinessActivities): Option[MlrAdvisor] = {
+    bact.accountantForAMLSRegulations match {
+      case Some(x) => Some(MlrAdvisor(x.accountantForAMLSRegulations, bact))
+      case _ if (!AmlsConfig.release7) => Some(MlrAdvisor(false))
+      case _ => None
     }
   }
 }

--- a/app/models/fe/businessactivities/BusinessActivities.scala
+++ b/app/models/fe/businessactivities/BusinessActivities.scala
@@ -77,20 +77,22 @@ object BusinessActivities {
 
   implicit def conv(desBA: Option[BusinessActivitiesAll]): BusinessActivities = {
     BusinessActivities(involvedInOther = desBA.fold[Option[InvolvedInOther]](None)(x => x.businessActivityDetails),
-      expectedBusinessTurnover = desBA.fold[Option[ExpectedBusinessTurnover]](None)(x =>x.businessActivityDetails),
-      expectedAMLSTurnover = desBA.fold[Option[ExpectedAMLSTurnover]](None)(x=> x.businessActivityDetails),
+      expectedBusinessTurnover = desBA.fold[Option[ExpectedBusinessTurnover]](None)(x => x.businessActivityDetails),
+      expectedAMLSTurnover = desBA.fold[Option[ExpectedAMLSTurnover]](None)(x => x.businessActivityDetails),
       businessFranchise = desBA.fold[Option[BusinessFranchise]](None)(x => x.franchiseDetails),
       transactionRecord = desBA.fold[Option[TransactionRecord]](None)(x => x),
       customersOutsideUK = desBA.fold[Option[CustomersOutsideUK]](None)(x => x),
       ncaRegistered = desBA.fold[Option[NCARegistered]](None)(x => Some(NCARegistered(x.nationalCrimeAgencyRegistered))),
       accountantForAMLSRegulations = desBA.fold[Option[AccountantForAMLSRegulations]](None)(x =>
-        Some(AccountantForAMLSRegulations(x.mlrAdvisor.doYouHaveMlrAdvisor))),
+        Some(AccountantForAMLSRegulations(x.mlrAdvisor match { case Some(x) => x.doYouHaveMlrAdvisor
+        case None => false
+        }))),
       identifySuspiciousActivity = desBA.fold[Option[IdentifySuspiciousActivity]](None)(x =>
         Some(IdentifySuspiciousActivity(x.suspiciousActivityGuidance))),
       riskAssessmentPolicy = desBA.fold[Option[RiskAssessmentPolicy]](None)(x => x.formalRiskAssessmentDetails),
       howManyEmployees = desBA.fold[Option[HowManyEmployees]](None)(x => x),
       whoIsYourAccountant = desBA.fold[Option[WhoIsYourAccountant]](None)(x => x.mlrAdvisor),
-      taxMatters = desBA.fold[Option[TaxMatters]](None)(x => x.mlrAdvisor.mlrAdvisorDetails)
+      taxMatters = desBA.fold[Option[TaxMatters]](None)(x => x.mlrAdvisor flatMap {mlrAdvisor => mlrAdvisor.mlrAdvisorDetails})
     )
   }
 

--- a/app/models/fe/businessactivities/WhoIsYourAccountant.scala
+++ b/app/models/fe/businessactivities/WhoIsYourAccountant.scala
@@ -28,24 +28,29 @@ object WhoIsYourAccountant {
 
   import play.api.libs.json._
 
-  implicit val jsonWrites : Writes[WhoIsYourAccountant] = Writes[WhoIsYourAccountant] { data:WhoIsYourAccountant =>
+  implicit val jsonWrites: Writes[WhoIsYourAccountant] = Writes[WhoIsYourAccountant] { data: WhoIsYourAccountant =>
     Json.obj("accountantsName" -> data.accountantsName,
-             "accountantsTradingName" -> data.accountantsTradingName) ++
+      "accountantsTradingName" -> data.accountantsTradingName) ++
       Json.toJson(data.address).as[JsObject]
   }
 
-  implicit val jsonReads : Reads[WhoIsYourAccountant] =
+  implicit val jsonReads: Reads[WhoIsYourAccountant] =
     ((__ \ "accountantsName").read[String] and
       (__ \ "accountantsTradingName").readNullable[String] and
-      __.read[AccountantsAddress])(WhoIsYourAccountant.apply _)
+      __.read[AccountantsAddress]) (WhoIsYourAccountant.apply _)
 
-  implicit def conv(mlrAdvisor: MlrAdvisor): Option[WhoIsYourAccountant] = {
-    mlrAdvisor.mlrAdvisorDetails match {
-      case Some(mlrDtls) => mlrDtls.advisorNameAddress match {
-        case Some(advisorDtls) => Some(WhoIsYourAccountant(advisorDtls.name, advisorDtls.tradingName, advisorDtls.address))
-        case None => None
-      }
-      case None => None
+  implicit def conv(mlrAdvisorOpt: Option[MlrAdvisor]): Option[WhoIsYourAccountant] = {
+
+    mlrAdvisorOpt flatMap {
+      mlrAdvisor =>
+        mlrAdvisor.mlrAdvisorDetails match {
+          case Some(mlrDtls) => mlrDtls.advisorNameAddress match {
+            case Some(advisorDtls) => Some(WhoIsYourAccountant(advisorDtls.name, advisorDtls.tradingName, advisorDtls.address))
+            case None => None
+          }
+          case None => None
+        }
     }
+
   }
 }

--- a/test/controllers/SubscriptionControllerSpec.scala
+++ b/test/controllers/SubscriptionControllerSpec.scala
@@ -29,7 +29,7 @@ import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.mock.MockitoSugar
-import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.{JsNull, JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -44,13 +44,14 @@ class SubscriptionControllerSpec
     with MockitoSugar
     with ScalaFutures
     with IntegrationPatience
-    with IterateeHelpers {
+    with IterateeHelpers
+    with OneAppPerSuite {
 
   object SubscriptionController extends SubscriptionController {
     override val service = mock[SubscriptionService]
   }
 
-   "SubscriptionController" must {
+  "SubscriptionController" must {
 
     val safeId = "XA0001234567890"
     // scalastyle:off
@@ -71,10 +72,10 @@ class SubscriptionControllerSpec
         ),
       eabSection = None,
       tradingPremisesSection = None,
-      aboutTheBusinessSection = AboutTheBusiness(PreviouslyRegisteredNo, Some(ActivityStartDate(new LocalDate(1990, 2, 24))),Some(VATRegisteredNo),
-        Some(CorporationTaxRegisteredYes("1234567890")),ContactingYou("123456789", "asas@gmail.com"), RegisteredOfficeUK("1", "2", None, None, "postcode")),
+      aboutTheBusinessSection = AboutTheBusiness(PreviouslyRegisteredNo, Some(ActivityStartDate(new LocalDate(1990, 2, 24))), Some(VATRegisteredNo),
+        Some(CorporationTaxRegisteredYes("1234567890")), ContactingYou("123456789", "asas@gmail.com"), RegisteredOfficeUK("1", "2", None, None, "postcode")),
       bankDetailsSection = Seq(BankDetails(PersonalAccount, BankAccount("name", NonUKAccountNumber("1234567896")))),
-      aboutYouSection = AddPerson("name",Some("name"),"name", RoleWithinBusiness(Set(Director))),
+      aboutYouSection = AddPerson("name", Some("name"), "name", RoleWithinBusiness(Set(Director))),
       businessActivitiesSection = BusinessActivities(None),
       responsiblePeopleSection = None,
       tcspSection = None,
@@ -88,11 +89,11 @@ class SubscriptionControllerSpec
       .withHeaders(CONTENT_TYPE -> "application/json")
       .withBody[JsValue](Json.toJson(body))
 
-     val requestWithEmptyBody = FakeRequest()
-       .withHeaders(CONTENT_TYPE -> "application/json")
-       .withBody[JsValue](JsNull)
+    val requestWithEmptyBody = FakeRequest()
+      .withHeaders(CONTENT_TYPE -> "application/json")
+      .withBody[JsValue](JsNull)
 
-     "return a `BadRequest` response when the safeId is invalid" in {
+    "return a `BadRequest` response when the safeId is invalid" in {
 
       val result = SubscriptionController.subscribe("test", "test", "test")(postRequest)
       val failure = Json.obj("errors" -> Seq("Invalid SafeId"))
@@ -129,7 +130,7 @@ class SubscriptionControllerSpec
         SubscriptionController.service.subscribe(eqTo(safeId), any())(any(), any())
       } thenReturn Future.failed(new HttpStatusException(INTERNAL_SERVER_ERROR, Some("message")))
 
-      whenReady (SubscriptionController.subscribe("test", "OrgRef", safeId)(postRequest).failed) {
+      whenReady(SubscriptionController.subscribe("test", "OrgRef", safeId)(postRequest).failed) {
         case HttpStatusException(status, body) =>
           status mustEqual INTERNAL_SERVER_ERROR
           body mustEqual Some("message")
@@ -140,27 +141,27 @@ class SubscriptionControllerSpec
 
       val response = Json.obj(
         "errors" -> Seq(
-            Json.obj(
-              "path" -> "obj.aboutTheBusinessSection",
-              "error" -> "error.path.missing"
-            ),
-            Json.obj(
-              "path" -> "obj.aboutYouSection",
-              "error" -> "error.path.missing"
-            ),
-            Json.obj(
-              "path" -> "obj.businessActivitiesSection",
-              "error" -> "error.path.missing"
-            ),
-            Json.obj(
-              "path" -> "obj.businessMatchingSection",
-              "error" -> "error.path.missing"
-            ),
-            Json.obj(
-              "path" -> "obj.bankDetailsSection",
-              "error" -> "error.path.missing"
-            )
+          Json.obj(
+            "path" -> "obj.aboutTheBusinessSection",
+            "error" -> "error.path.missing"
+          ),
+          Json.obj(
+            "path" -> "obj.aboutYouSection",
+            "error" -> "error.path.missing"
+          ),
+          Json.obj(
+            "path" -> "obj.businessActivitiesSection",
+            "error" -> "error.path.missing"
+          ),
+          Json.obj(
+            "path" -> "obj.businessMatchingSection",
+            "error" -> "error.path.missing"
+          ),
+          Json.obj(
+            "path" -> "obj.bankDetailsSection",
+            "error" -> "error.path.missing"
           )
+        )
       )
 
       val result = SubscriptionController.subscribe("test", "orgRef", safeId)(requestWithEmptyBody)

--- a/test/models/DefaultDesValues.scala
+++ b/test/models/DefaultDesValues.scala
@@ -53,7 +53,7 @@ object DefaultDesValues {
   private val nationalCrimeAgencyRegistered = true
   private val formalRiskAssessmentDetails = Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true))))
   private val advisorNameAddress = AdvisorNameAddress("Name", Some("TradingName"), ATBAddress("Line1", "Line2", Some("Line3"), Some("Line4"), "GB", Some("postcode")))
-  private val mlrAdvisor = MlrAdvisor(true, Some(MlrAdvisorDetails(Some(advisorNameAddress), true, None)))
+  private val mlrAdvisor = Some(MlrAdvisor(true, Some(MlrAdvisorDetails(Some(advisorNameAddress), true, None))))
   private val desallActivitiesModel = Some(BusinessActivitiesAll(None,Some("1990-02-24"),None, activityDetails, franchiseDetails, noOfEmployees, noOfEmployeesForMlr,
     nonUkResidentCustDetails, auditableRecordsDetails, suspiciousActivityGuidance, nationalCrimeAgencyRegistered,
     formalRiskAssessmentDetails, mlrAdvisor))

--- a/test/models/des/DesConstants.scala
+++ b/test/models/des/DesConstants.scala
@@ -103,7 +103,7 @@ object DesConstants {
     true,
     true,
     Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-    MlrAdvisor(true, Some(MlrAdvisorDetails(
+    Some(MlrAdvisor(true, Some(MlrAdvisorDetails(
       Some(AdvisorNameAddress("Name", Some("TradingName"), AboutTheBusinessAddress(
         "AdvisorAddressLine1",
         "AdvisorAddressLine2",
@@ -113,7 +113,7 @@ object DesConstants {
         Some("Postcode")))),
       true,
       None
-    )))
+    ))))
   )
 
   val testBusinessActivitiesAllWithDateChangeFlag = BusinessActivitiesAll(
@@ -129,7 +129,7 @@ object DesConstants {
     true,
     true,
     Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-    MlrAdvisor(true, Some(MlrAdvisorDetails(
+    Some(MlrAdvisor(true, Some(MlrAdvisorDetails(
       Some(AdvisorNameAddress("Name", Some("TradingName"), AboutTheBusinessAddress(
         "AdvisorAddressLine1",
         "AdvisorAddressLine2",
@@ -139,7 +139,7 @@ object DesConstants {
         Some("Postcode")))),
       true,
       None
-    )))
+    ))))
   )
 
   val testBusinessActivities = BusinessActivities(

--- a/test/models/des/SubscriptionRequestSpec.scala
+++ b/test/models/des/SubscriptionRequestSpec.scala
@@ -623,8 +623,8 @@ class SubscriptionRequestSpecRelease7 extends PlaySpec with MockitoSugar with On
       val desallActivitiesModel = BusinessActivitiesAll(None, Some("2001-01-01"), None, BusinessActivityDetails(true,
         Some(ExpectedAMLSTurnover(Some("£0-£15k")))), Some(FranchiseDetails(true, Some(Seq("Name")))), Some("10"), Some("5"),
         NonUkResidentCustDetails(true, Some(Seq("GB", "AB"))), AuditableRecordsDetails("Yes", Some(TransactionRecordingMethod(true, true, true, Some("value")))),
-        true, true, Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true)))), MlrAdvisor(true,
-          Some(MlrAdvisorDetails(Some(AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"), "GB", Some("postcode")))), true, None))))
+        true, true, Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true)))), Some(MlrAdvisor(true,
+          Some(MlrAdvisorDetails(Some(AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"), "GB", Some("postcode")))), true, None)))))
 
       val desSubscriptionReq =
         des.SubscriptionRequest(
@@ -710,8 +710,8 @@ class SubscriptionRequestSpecRelease7 extends PlaySpec with MockitoSugar with On
   val desallActivitiesModel = BusinessActivitiesAll(None,Some("2001-01-01"),None, BusinessActivityDetails(true,
     Some(ExpectedAMLSTurnover(Some("£0-£15k")))), Some(FranchiseDetails(true, Some(Seq("Name")))),  Some("10"), Some("5"),
     NonUkResidentCustDetails(true, Some(Seq("GB", "AB"))), AuditableRecordsDetails("Yes", Some(TransactionRecordingMethod(true, true, true, Some("value")))),
-    true, true, Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true)))), MlrAdvisor(true,
-      Some(MlrAdvisorDetails(Some(AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"), "GB", Some("postcode")))), true, None))))
+    true, true, Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true)))), Some(MlrAdvisor(true,
+      Some(MlrAdvisorDetails(Some(AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"), "GB", Some("postcode")))), true, None)))))
 
   val desSubscriptionReq =
     des.SubscriptionRequest(

--- a/test/models/des/businessActivities/BusinessActivitiesAllSpec.scala
+++ b/test/models/des/businessActivities/BusinessActivitiesAllSpec.scala
@@ -44,7 +44,7 @@ class BusinessActivitiesAllSpec extends PlaySpec with OneAppPerSuite {
       val nationalCrimeAgencyRegistered = true
       val formalRiskAssessmentDetails = Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true))))
       val advisorNameAddress = AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"),"GB", None))
-      val mlrAdvisor = MlrAdvisor(true, Some(MlrAdvisorDetails(Some(advisorNameAddress), true, None)))
+      val mlrAdvisor = Some(MlrAdvisor(true, Some(MlrAdvisorDetails(Some(advisorNameAddress), true, None))))
 
       val model = BusinessActivitiesAll(Some("2016-05-25"), None, None, activityDetails, franchiseDetails, noOfEmployees, noOfEmployeesForMlr,
         nonUkResidentCustDetails, auditableRecordsDetails, suspiciousActivityGuidance, nationalCrimeAgencyRegistered,
@@ -90,7 +90,7 @@ class BusinessActivitiesAllSpec extends PlaySpec with OneAppPerSuite {
         true,
         true,
         Some(FormalRiskAssessmentDetails(true,Some(RiskAssessmentFormat(true,true)))),
-        MlrAdvisor(
+        Some(MlrAdvisor(
           true,
           Some(
             MlrAdvisorDetails(
@@ -107,7 +107,7 @@ class BusinessActivitiesAllSpec extends PlaySpec with OneAppPerSuite {
                     None))),
               true,
               None)
-          ))))
+          )))))
 
       BusinessActivitiesAll.convert(AboutTheBusinessSection.model,
         BusinessActivitiesSection.modelForView, Some("2000-11-11"), true) must be(model)

--- a/test/models/des/businessActivities/BusinessActivitiesSpec.scala
+++ b/test/models/des/businessActivities/BusinessActivitiesSpec.scala
@@ -81,7 +81,7 @@ class BusinessActivitiesSpec extends PlaySpec {
     val nationalCrimeAgencyRegistered = true
     val formalRiskAssessmentDetails = Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true))))
     val advisorNameAddress = AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"),"GB", None))
-    val mlrAdvisor = MlrAdvisor(true, Some(MlrAdvisorDetails(Some(advisorNameAddress), true, None)))
+    val mlrAdvisor = Some(MlrAdvisor(true, Some(MlrAdvisorDetails(Some(advisorNameAddress), true, None))))
     val activitiesModel = BusinessActivitiesAll(None, None,None, activityDetails, franchiseDetails, noOfEmployees, noOfEmployeesForMlr,
       nonUkResidentCustDetails, auditableRecordsDetails, suspiciousActivityGuidance, nationalCrimeAgencyRegistered,
       formalRiskAssessmentDetails, mlrAdvisor)

--- a/test/models/fe/aboutthebusiness/ActivityStartDateSpec.scala
+++ b/test/models/fe/aboutthebusiness/ActivityStartDateSpec.scala
@@ -59,7 +59,7 @@ class ActivityStartDateSpec extends PlaySpec {
         true,
         true,
         Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-        MlrAdvisor(false, None)
+        None
       ))
       ActivityStartDate.conv(desModel) must be(None)
 

--- a/test/models/fe/businessactivities/BusinessActivitiesSpec.scala
+++ b/test/models/fe/businessactivities/BusinessActivitiesSpec.scala
@@ -129,7 +129,7 @@ class BusinessActivitiesSpec extends PlaySpec with MockitoSugar with OneAppPerSu
         true,
         true,
         Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-        MlrAdvisor(
+        Some(MlrAdvisor(
           true,
           Some(MlrAdvisorDetails(
             Some(AdvisorNameAddress(
@@ -144,7 +144,7 @@ class BusinessActivitiesSpec extends PlaySpec with MockitoSugar with OneAppPerSu
                 Some("Postcode")))),
             true,
             Some("01234567890")
-        )))
+        ))))
       ))
 
       val feModel = BusinessActivities(Some(InvolvedInOtherNo),None,None,Some(BusinessFranchiseYes("FranchiserName1")),

--- a/test/models/fe/businessactivities/CustomersOutsideUKSpec.scala
+++ b/test/models/fe/businessactivities/CustomersOutsideUKSpec.scala
@@ -44,7 +44,7 @@ class CustomersOutsideUKSpec extends PlaySpec {
         true,
         true,
         Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-        MlrAdvisor(false, None))
+        None)
 
       CustomersOutsideUK.conv(businessActivitiesAll) must be(Some(CustomersOutsideUK(true, Some(List("AD", "GB")))))
     }
@@ -62,7 +62,7 @@ class CustomersOutsideUKSpec extends PlaySpec {
         true,
         true,
         Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-        MlrAdvisor(false, None))
+        None)
 
       CustomersOutsideUK.conv(businessActivitiesAll) must be(Some(CustomersOutsideUK(false, None)))
     }

--- a/test/models/fe/businessactivities/HowManyEmployeesSpec.scala
+++ b/test/models/fe/businessactivities/HowManyEmployeesSpec.scala
@@ -70,7 +70,7 @@ class HowManyEmployeesSpec extends PlaySpec {
         true,
         true,
         None,
-        MlrAdvisor(false, None)
+        None
       )
       HowManyEmployees.conv(all) must be(Some(HowManyEmployees("12345678901", "11223344556")))
     }
@@ -88,7 +88,7 @@ class HowManyEmployeesSpec extends PlaySpec {
         true,
         true,
         None,
-        MlrAdvisor(false, None)
+        None
       )
       HowManyEmployees.conv(all) must be(None)
     }

--- a/test/models/fe/businessactivities/TransactionRecordSpec.scala
+++ b/test/models/fe/businessactivities/TransactionRecordSpec.scala
@@ -89,7 +89,7 @@ class TransactionRecordSpec extends PlaySpec with MockitoSugar {
         true,
         true,
         Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-        MlrAdvisor(false, None))
+        None)
 
       TransactionRecord.conv(businessActivitiesAll) must be(Some(TransactionRecordYes(Set(Paper,
         DigitalSpreadsheet, DigitalSoftware("CommercialPackageName")))))
@@ -108,7 +108,7 @@ class TransactionRecordSpec extends PlaySpec with MockitoSugar {
         true,
         true,
         Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true, true)))),
-        MlrAdvisor(false, None))
+        None)
 
       TransactionRecord.conv(businessActivitiesAll) must be(Some(TransactionRecordNo))
     }

--- a/test/models/fe/businessactivities/WhoIsYourAccountantSpec.scala
+++ b/test/models/fe/businessactivities/WhoIsYourAccountantSpec.scala
@@ -52,7 +52,7 @@ class WhoIsYourAccountantSpec extends WordSpec with Matchers {
     }
 
     "convert des to frontend model successfully" in {
-      val mlrAdvisor = MlrAdvisor(true, Some(MlrAdvisorDetails(
+      val mlrAdvisor = Some(MlrAdvisor(true, Some(MlrAdvisorDetails(
         Some(AdvisorNameAddress("Name", Some("TradingName"), Address(
           "AdvisorAddressLine1",
           "AdvisorAddressLine2",
@@ -62,7 +62,7 @@ class WhoIsYourAccountantSpec extends WordSpec with Matchers {
           Some("AA1 1AA")))),
         true,
         Some("01234567890")
-      )))
+      ))))
 
       WhoIsYourAccountant.conv(mlrAdvisor) shouldBe Some(WhoIsYourAccountant(
         "Name",
@@ -71,7 +71,7 @@ class WhoIsYourAccountantSpec extends WordSpec with Matchers {
     }
 
     "convert des to frontend model successfully for nonuk address" in {
-      val mlrAdvisor = MlrAdvisor(true, Some(MlrAdvisorDetails(
+      val mlrAdvisor = Some(MlrAdvisor(true, Some(MlrAdvisorDetails(
         Some(AdvisorNameAddress("Name", Some("TradingName"), Address(
           "line1",
           "line2",
@@ -81,24 +81,30 @@ class WhoIsYourAccountantSpec extends WordSpec with Matchers {
           None))),
         false,
         None
-      )))
+      ))))
 
       WhoIsYourAccountant.conv(mlrAdvisor) shouldBe Some(WhoIsYourAccountant("Name",Some("TradingName"),
         NonUkAccountantsAddress("line1","line2",Some("line3"),Some("line4"),"GB")))
     }
 
+    "convert des to frontend model successfully when MlrAdvisor None" in {
+      val mlrAdvisor = None
+
+      WhoIsYourAccountant.conv(mlrAdvisor) shouldBe None
+    }
+
     "convert des to frontend model successfully when MlrAdvisorDetails None" in {
-      val mlrAdvisor = MlrAdvisor(false, None)
+      val mlrAdvisor = Some(MlrAdvisor(false, None))
 
       WhoIsYourAccountant.conv(mlrAdvisor) shouldBe None
     }
 
     "convert des to frontend model successfully when AdvisorNameAddress None" in {
-      val mlrAdvisor = MlrAdvisor(true, Some(MlrAdvisorDetails(
+      val mlrAdvisor = Some(MlrAdvisor(true, Some(MlrAdvisorDetails(
         None,
         false,
         None
-      )))
+      ))))
 
       WhoIsYourAccountant.conv(mlrAdvisor) shouldBe None
     }


### PR DESCRIPTION
mlrAdvisor is optional in all schemas in R7. Changed to optional in AMLS as if it is sent as empty it will not come back at all in API5. Left it so it continues to send empty object in R6 as it's mandatory in R6.