### PR TITLE
AMLS-2950: Models for new API 1b - RegistrationDetails

### DIFF
--- a/app/connectors/DESConnector.scala
+++ b/app/connectors/DESConnector.scala
@@ -65,7 +65,8 @@ object DESConnector extends SubscribeDESConnector
   with ViewDESConnector
   with AmendVariationDESConnector
   with WithdrawSubscriptionConnector
-  with DeregisterSubscriptionConnector {
+  with DeregisterSubscriptionConnector
+  with RegistrationDetailsDesConnector {
 
   // $COVERAGE-OFF$
   override private[connectors] lazy val baseUrl: String = AmlsConfig.desUrl

--- a/app/connectors/RegistrationDetailsDesConnector.scala
+++ b/app/connectors/RegistrationDetailsDesConnector.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import models.des.registrationdetails.RegistrationDetails
+import play.api.Logger
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait RegistrationDetailsDesConnector extends DESConnector  {
+
+  override val requestUrl = "anti-money-laundering/registration"
+
+  private val debug: String => String => Unit = method => msg => Logger.debug(s"[RegistrationDetailsConnector.$method] $msg")
+
+  def getRegistrationDetails(safeId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[RegistrationDetails] = {
+    val d = debug("getRegistrationDetails")
+    val url = s"$fullUrl/details?safeid=$safeId"
+
+    d(s"Requesting registration details for $safeId")
+    httpGet.GET[RegistrationDetails](url) map { result =>
+      d(s"Response: ${result.toString}")
+      result
+    }
+  }
+
+}

--- a/app/controllers/RegistrationDetailsController.scala
+++ b/app/controllers/RegistrationDetailsController.scala
@@ -26,7 +26,7 @@ trait RegistrationDetailsController extends BaseController {
 
   def get(safeId: String) = Action.async {
     implicit request =>
-      registrationDetailsConnector.getRegistrationDetails(safeId) map { _ =>
+      registrationDetailsConnector.getRegistrationDetails(safeId) map { details =>
         Ok
       }
   }

--- a/app/controllers/RegistrationDetailsController.scala
+++ b/app/controllers/RegistrationDetailsController.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import connectors.{DESConnector, RegistrationDetailsDesConnector}
+import play.api.mvc.Action
+import uk.gov.hmrc.play.microservice.controller.BaseController
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait RegistrationDetailsController extends BaseController {
+  private[controllers] val registrationDetailsConnector: RegistrationDetailsDesConnector
+
+  def get(safeId: String) = Action.async {
+    implicit request =>
+      registrationDetailsConnector.getRegistrationDetails(safeId) map { _ =>
+        Ok
+      }
+  }
+}
+
+object RegistrationDetailsController extends RegistrationDetailsController {
+  private[controllers] lazy val registrationDetailsConnector = DESConnector
+}

--- a/app/controllers/RegistrationDetailsController.scala
+++ b/app/controllers/RegistrationDetailsController.scala
@@ -17,8 +17,10 @@
 package controllers
 
 import connectors.{DESConnector, RegistrationDetailsDesConnector}
+import play.api.libs.json.Json
 import play.api.mvc.Action
 import uk.gov.hmrc.play.microservice.controller.BaseController
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait RegistrationDetailsController extends BaseController {
@@ -27,7 +29,7 @@ trait RegistrationDetailsController extends BaseController {
   def get(safeId: String) = Action.async {
     implicit request =>
       registrationDetailsConnector.getRegistrationDetails(safeId) map { details =>
-        Ok
+        Ok(Json.toJson(details))
       }
   }
 }

--- a/app/models/des/registrationdetails/RegistrationDetails.scala
+++ b/app/models/des/registrationdetails/RegistrationDetails.scala
@@ -26,13 +26,27 @@ case object CorporateBody extends OrganisationType
 case object UnincorporatedBody extends OrganisationType
 
 object OrganisationType {
+
+  val orgTypeToString = Map[OrganisationType, String](
+    Partnership -> "Partnership",
+    LLP -> "LLP",
+    CorporateBody -> "Corporate body",
+    UnincorporatedBody -> "Unincorporated body"
+  )
+
+  val stringToOrgType = orgTypeToString.map(_.swap)
+
   implicit val reads = new Reads[OrganisationType] {
     override def reads(json: JsValue) = json match {
-      case JsString("Partnership") => JsSuccess(Partnership)
-      case JsString("LLP") => JsSuccess(LLP)
-      case JsString("Corporate body") => JsSuccess(CorporateBody)
-      case JsString("Unincorporated body") => JsSuccess(UnincorporatedBody)
+      case JsString(x) if stringToOrgType.isDefinedAt(x) => JsSuccess(stringToOrgType(x))
       case x => JsError(s"Unable to parse the organisation type value: $x")
+    }
+  }
+
+  implicit val writes = new Writes[OrganisationType] {
+    override def writes(o: OrganisationType) = o match {
+      case org if orgTypeToString.isDefinedAt(org) => JsString(orgTypeToString(org))
+      case _ => throw new Exception("Unable to convert org type to string")
     }
   }
 }
@@ -41,21 +55,30 @@ sealed trait OrganisationBodyDetails
 case class Organisation(organisationName: String, isAGroup: Boolean, organisationType: OrganisationType) extends OrganisationBodyDetails
 
 object Organisation {
-  implicit val orgReads = Json.reads[Organisation]
+  implicit val format = Json.format[Organisation]
 }
 
 case class Individual(firstName: String, middleName: Option[String], lastName: String, dateOfBirth: LocalDate) extends OrganisationBodyDetails
 
 object Individual {
-  implicit val indReads = Json.reads[Individual]
+  implicit val format = Json.format[Individual]
 }
 
 object OrganisationBodyDetails {
+  import play.api.libs.json._
+  import play.api.libs.functional.syntax._
+
   implicit val reads: Reads[OrganisationBodyDetails] = {
-    import play.api.libs.json._
     (__ \ "isAnIndividual").read[Boolean] flatMap {
       case true => (__ \ "individual").read[Individual].map(identity[OrganisationBodyDetails])
       case _ => (__ \ "organisation").read[Organisation].map(identity[OrganisationBodyDetails])
+    }
+  }
+
+  implicit val writes = new Writes[OrganisationBodyDetails] {
+    override def writes(o: OrganisationBodyDetails) = o match {
+      case x: Organisation => Json.obj("organisation" -> Organisation.format.writes(x))
+      case x: Individual => Json.obj("individual" -> Individual.format.writes(x))
     }
   }
 }
@@ -63,12 +86,20 @@ object OrganisationBodyDetails {
 case class RegistrationDetails(isAnIndividual: Boolean, bodyDetails: OrganisationBodyDetails)
 
 object RegistrationDetails {
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json._
+
   implicit val reads: Reads[RegistrationDetails] = {
-    import play.api.libs.functional.syntax._
-    import play.api.libs.json._
     (
       (__ \ "isAnIndividual").read[Boolean] and
         __.read[OrganisationBodyDetails]
     )(RegistrationDetails.apply _)
+  }
+
+  implicit val writes: Writes[RegistrationDetails] = {
+    (
+      (__ \ "isAnIndividual").write[Boolean] and
+      __.write[OrganisationBodyDetails]
+      )(unlift(RegistrationDetails.unapply))
   }
 }

--- a/app/models/des/registrationdetails/RegistrationDetails.scala
+++ b/app/models/des/registrationdetails/RegistrationDetails.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.des.registrationdetails
+
+import org.joda.time.LocalDate
+import play.api.libs.json._
+
+sealed trait OrganisationType
+case object Partnership extends OrganisationType
+case object LLP extends OrganisationType
+case object CorporateBody extends OrganisationType
+case object UnincorporatedBody extends OrganisationType
+
+object OrganisationType {
+  implicit val reads = new Reads[OrganisationType] {
+    override def reads(json: JsValue) = json match {
+      case JsString("Partnership") => JsSuccess(Partnership)
+      case JsString("LLP") => JsSuccess(LLP)
+      case JsString("Corporate body") => JsSuccess(CorporateBody)
+      case JsString("Unincorporated body") => JsSuccess(UnincorporatedBody)
+      case x => JsError(s"Unable to parse the organisation type value: $x")
+    }
+  }
+}
+
+sealed trait OrganisationBodyDetails
+case class Organisation(organisationName: String, isAGroup: Boolean, organisationType: OrganisationType) extends OrganisationBodyDetails
+
+object Organisation {
+  implicit val orgReads = Json.reads[Organisation]
+}
+
+case class Individual(firstName: String, middleName: Option[String], lastName: String, dateOfBirth: LocalDate) extends OrganisationBodyDetails
+
+object Individual {
+  implicit val indReads = Json.reads[Individual]
+}
+
+object OrganisationBodyDetails {
+  implicit val reads: Reads[OrganisationBodyDetails] = {
+    import play.api.libs.json._
+    (__ \ "isAnIndividual").read[Boolean] flatMap {
+      case true => (__ \ "individual").read[Individual].map(identity[OrganisationBodyDetails])
+      case _ => (__ \ "organisation").read[Organisation].map(identity[OrganisationBodyDetails])
+    }
+  }
+}
+
+case class RegistrationDetails(isAnIndividual: Boolean, bodyDetails: OrganisationBodyDetails)
+
+object RegistrationDetails {
+  implicit val reads: Reads[RegistrationDetails] = {
+    import play.api.libs.functional.syntax._
+    import play.api.libs.json._
+    (
+      (__ \ "isAnIndividual").read[Boolean] and
+        __.read[OrganisationBodyDetails]
+    )(RegistrationDetails.apply _)
+  }
+}

--- a/app/models/des/registrationdetails/RegistrationDetails.scala
+++ b/app/models/des/registrationdetails/RegistrationDetails.scala
@@ -66,7 +66,6 @@ object Individual {
 
 object OrganisationBodyDetails {
   import play.api.libs.json._
-  import play.api.libs.functional.syntax._
 
   implicit val reads: Reads[OrganisationBodyDetails] = {
     (__ \ "isAnIndividual").read[Boolean] flatMap {

--- a/test/connectors/RegistrationDetailsDesConnectorSpec.scala
+++ b/test/connectors/RegistrationDetailsDesConnectorSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import audit.MockAudit
+import metrics.Metrics
+import models.des.registrationdetails.{Organisation, Partnership, RegistrationDetails}
+import org.mockito.Mockito._
+import org.mockito.Matchers.{eq => eqTo, _}
+import org.scalatest.{BeforeAndAfter, MustMatchers}
+import org.scalatest.concurrent._
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RegistrationDetailsDesConnectorSpec extends PlaySpec with MustMatchers with ScalaFutures with MockitoSugar with BeforeAndAfter {
+
+  val mockHttpGet = mock[HttpGet]
+
+  val connector = new RegistrationDetailsDesConnector {
+    override private[connectors] def baseUrl = "baseUrl"
+    override private[connectors] def env = "ist0"
+    override private[connectors] def token = "token"
+    override private[connectors] def httpPost = mock[HttpPost]
+    override private[connectors] def httpGet = mockHttpGet
+    override private[connectors] def metrics = mock[Metrics]
+    override private[connectors] def audit = MockAudit
+    override private[connectors] def auditConnector = mock[AuditConnector]
+    override private[connectors] def fullUrl = s"$baseUrl/$requestUrl"
+  }
+
+  implicit val headerCarrier = HeaderCarrier()
+
+  before {
+    reset(mockHttpGet)
+  }
+
+  "The RegistrationDetailsDesConnector" must {
+    "get the registration details" in {
+
+      val safeId = "SAFEID"
+      val details = RegistrationDetails(isAnIndividual = false, Organisation("Test organisation", false, Partnership))
+
+      when {
+        mockHttpGet.GET[RegistrationDetails](eqTo(s"${connector.fullUrl}/details?safeid=$safeId"))(any(), any())
+      } thenReturn Future.successful(details)
+
+      whenReady (connector.getRegistrationDetails(safeId)) { r =>
+        r mustBe details
+      }
+
+    }
+  }
+
+}

--- a/test/controllers/RegistrationDetailsControllerSpec.scala
+++ b/test/controllers/RegistrationDetailsControllerSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import connectors.RegistrationDetailsDesConnector
+import models.des.registrationdetails.RegistrationDetails
+import org.mockito.Matchers.{eq => eqTo, _}
+import org.mockito.Mockito._
+import org.scalatest.MustMatchers
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import play.api.test.FakeRequest
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class RegistrationDetailsControllerSpec extends PlaySpec with MustMatchers with ScalaFutures with MockitoSugar {
+
+  implicit val hc = HeaderCarrier()
+
+  val controller = new RegistrationDetailsController {
+    override private[controllers] val registrationDetailsConnector = mock[RegistrationDetailsDesConnector]
+  }
+
+  "The RegistrationDetailsController" must {
+    "use the Des connector to retrieve registration details" in {
+      val safeId = "SAFEID"
+
+      when {
+        controller.registrationDetailsConnector.getRegistrationDetails(eqTo(safeId))(any(), any())
+      } thenReturn Future.successful(mock[RegistrationDetails])
+
+      whenReady(controller.get(safeId)(FakeRequest())) { _ =>
+        verify(controller.registrationDetailsConnector).getRegistrationDetails(eqTo(safeId))(any(), any())
+      }
+    }
+  }
+
+}

--- a/test/controllers/RegistrationDetailsControllerSpec.scala
+++ b/test/controllers/RegistrationDetailsControllerSpec.scala
@@ -17,14 +17,16 @@
 package controllers
 
 import connectors.RegistrationDetailsDesConnector
-import models.des.registrationdetails.RegistrationDetails
+import models.des.registrationdetails.{CorporateBody, Organisation, RegistrationDetails}
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.MustMatchers
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.Json
 import play.api.test.FakeRequest
+import play.api.test.Helpers._
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -40,14 +42,17 @@ class RegistrationDetailsControllerSpec extends PlaySpec with MustMatchers with 
   "The RegistrationDetailsController" must {
     "use the Des connector to retrieve registration details" in {
       val safeId = "SAFEID"
+      val details = RegistrationDetails(isAnIndividual = false, Organisation("Test Org", isAGroup = false, CorporateBody))
 
       when {
         controller.registrationDetailsConnector.getRegistrationDetails(eqTo(safeId))(any(), any())
-      } thenReturn Future.successful(mock[RegistrationDetails])
+      } thenReturn Future.successful(details)
 
-      whenReady(controller.get(safeId)(FakeRequest())) { _ =>
-        verify(controller.registrationDetailsConnector).getRegistrationDetails(eqTo(safeId))(any(), any())
-      }
+      val response = controller.get(safeId)(FakeRequest())
+
+      status(response) mustBe OK
+      contentAsJson(response) mustBe Json.toJson(details)
+      verify(controller.registrationDetailsConnector).getRegistrationDetails(eqTo(safeId))(any(), any())
     }
   }
 

--- a/test/models/des/registrationdetails/RegistrationDetailsSpec.scala
+++ b/test/models/des/registrationdetails/RegistrationDetailsSpec.scala
@@ -42,6 +42,7 @@ class RegistrationDetailsSpec extends PlaySpec with MustMatchers {
         }
 
         "the data represents an individual" in {
+          //noinspection ScalaStyle
           val expectedModel = RegistrationDetails(true, Individual("Firstname", Some("Middlename"), "Lastname", new LocalDate(2002, 5, 10)))
 
           val json = Json.obj(

--- a/test/models/des/registrationdetails/RegistrationDetailsSpec.scala
+++ b/test/models/des/registrationdetails/RegistrationDetailsSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.des.registrationdetails
+
+import org.joda.time.LocalDate
+import org.scalatest.MustMatchers
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.{JsString, JsSuccess, Json}
+
+class RegistrationDetailsSpec extends PlaySpec with MustMatchers {
+
+  "The RegistrationDetails model" when {
+    "deserialised" must {
+      "produce the correct json" when {
+        "the data represents an organisation" in {
+          val expectedModel = RegistrationDetails(false, Organisation("Test Organisation", true, LLP))
+
+          val json = Json.obj(
+            "isAnIndividual" -> false,
+            "organisation" -> Json.obj(
+              "organisationName" -> "Test Organisation",
+              "isAGroup" -> true,
+              "organisationType" -> "LLP"
+            )
+          )
+
+          Json.fromJson[RegistrationDetails](json) mustBe JsSuccess(expectedModel)
+        }
+
+        "the data represents an individual" in {
+          val expectedModel = RegistrationDetails(true, Individual("Firstname", Some("Middlename"), "Lastname", new LocalDate(2002, 5, 10)))
+
+          val json = Json.obj(
+            "isAnIndividual" -> true,
+            "individual" -> Json.obj(
+              "firstName" -> "Firstname",
+              "middleName" -> "Middlename",
+              "lastName" -> "Lastname",
+              "dateOfBirth" -> "2002-05-10"
+            ))
+
+          Json.fromJson[RegistrationDetails](json) mustBe JsSuccess(expectedModel)
+        }
+      }
+    }
+  }
+
+  "The Organisation model" when {
+    "deserialised" must {
+      "produce the correct json" in {
+        val expectedModel = Organisation("Test Organisation", true, Partnership)
+
+        val json = Json.obj(
+          "organisationName" -> "Test Organisation",
+          "isAGroup" -> true,
+          "organisationType" -> "Partnership"
+        )
+
+        Json.fromJson[Organisation](json) mustBe JsSuccess(expectedModel)
+      }
+    }
+  }
+
+  "The organisation type objects" when {
+    "deserialised" must {
+      "produce the correct values" in {
+        Seq(
+          (Partnership, "Partnership"),
+          (LLP, "LLP"),
+          (CorporateBody, "Corporate body"),
+          (UnincorporatedBody, "Unincorporated body")
+        ) foreach {
+          case (t, str) => Json.fromJson[OrganisationType](JsString(str)) mustBe JsSuccess(t)
+        }
+      }
+    }
+  }
+
+}

--- a/test/models/des/registrationdetails/RegistrationDetailsSpec.scala
+++ b/test/models/des/registrationdetails/RegistrationDetailsSpec.scala
@@ -24,68 +24,123 @@ import play.api.libs.json.{JsString, JsSuccess, Json}
 class RegistrationDetailsSpec extends PlaySpec with MustMatchers {
 
   "The RegistrationDetails model" when {
+
+    val organisationJson = Json.obj(
+      "isAnIndividual" -> false,
+      "organisation" -> Json.obj(
+        "organisationName" -> "Test Organisation",
+        "isAGroup" -> true,
+        "organisationType" -> "LLP"
+      )
+    )
+
+    val organisationModel = RegistrationDetails(isAnIndividual = false, Organisation("Test Organisation", isAGroup = true, LLP))
+
+    val individualJson = Json.obj(
+      "isAnIndividual" -> true,
+      "individual" -> Json.obj(
+        "firstName" -> "Firstname",
+        "middleName" -> "Middlename",
+        "lastName" -> "Lastname",
+        "dateOfBirth" -> "2002-05-10"
+      ))
+
+    //noinspection ScalaStyle
+    val individualModel = RegistrationDetails(isAnIndividual = true, Individual("Firstname", Some("Middlename"), "Lastname", new LocalDate(2002, 5, 10)))
+
     "deserialised" must {
       "produce the correct json" when {
         "the data represents an organisation" in {
-          val expectedModel = RegistrationDetails(false, Organisation("Test Organisation", true, LLP))
-
-          val json = Json.obj(
-            "isAnIndividual" -> false,
-            "organisation" -> Json.obj(
-              "organisationName" -> "Test Organisation",
-              "isAGroup" -> true,
-              "organisationType" -> "LLP"
-            )
-          )
-
-          Json.fromJson[RegistrationDetails](json) mustBe JsSuccess(expectedModel)
+          Json.fromJson[RegistrationDetails](organisationJson) mustBe JsSuccess(organisationModel)
         }
 
         "the data represents an individual" in {
-          //noinspection ScalaStyle
-          val expectedModel = RegistrationDetails(true, Individual("Firstname", Some("Middlename"), "Lastname", new LocalDate(2002, 5, 10)))
+          Json.fromJson[RegistrationDetails](individualJson) mustBe JsSuccess(individualModel)
+        }
+      }
+    }
 
-          val json = Json.obj(
-            "isAnIndividual" -> true,
-            "individual" -> Json.obj(
-              "firstName" -> "Firstname",
-              "middleName" -> "Middlename",
-              "lastName" -> "Lastname",
-              "dateOfBirth" -> "2002-05-10"
-            ))
+    "serialised" must {
+      "produce the correct json" when {
+        "the data represents an organisation" in {
+          Json.toJson(organisationModel) mustBe organisationJson
+        }
 
-          Json.fromJson[RegistrationDetails](json) mustBe JsSuccess(expectedModel)
+        "the data represents an individual" in {
+          Json.toJson(individualModel) mustBe individualJson
         }
       }
     }
   }
 
   "The Organisation model" when {
+
+    val model = Organisation("Test Organisation", true, Partnership)
+
+    val json = Json.obj(
+      "organisationName" -> "Test Organisation",
+      "isAGroup" -> true,
+      "organisationType" -> "Partnership"
+    )
+
     "deserialised" must {
+      "produce the correct model" in {
+        Json.fromJson[Organisation](json) mustBe JsSuccess(model)
+      }
+    }
+
+    "serialised" must {
       "produce the correct json" in {
-        val expectedModel = Organisation("Test Organisation", true, Partnership)
+        Json.toJson(model) mustBe json
+      }
+    }
+  }
 
-        val json = Json.obj(
-          "organisationName" -> "Test Organisation",
-          "isAGroup" -> true,
-          "organisationType" -> "Partnership"
-        )
+  "The Individual model" when {
+    //noinspection ScalaStyle
+    val model = Individual("Firstname", Some("Middlename"), "Lastname", new LocalDate(2002, 5, 10))
 
-        Json.fromJson[Organisation](json) mustBe JsSuccess(expectedModel)
+    val json = Json.obj(
+      "firstName" -> "Firstname",
+      "middleName" -> "Middlename",
+      "lastName" -> "Lastname",
+      "dateOfBirth" -> "2002-05-10"
+    )
+
+    "deserialised" must {
+      "produce the correct model" in {
+        Json.fromJson[Individual](json) mustBe JsSuccess(model)
+      }
+    }
+
+    "serialised" must {
+      "produce the correct json" in {
+        Json.toJson(model) mustBe json
       }
     }
   }
 
   "The organisation type objects" when {
+
+    val types = Seq(
+      (Partnership, "Partnership"),
+      (LLP, "LLP"),
+      (CorporateBody, "Corporate body"),
+      (UnincorporatedBody, "Unincorporated body")
+    )
+
     "deserialised" must {
       "produce the correct values" in {
-        Seq(
-          (Partnership, "Partnership"),
-          (LLP, "LLP"),
-          (CorporateBody, "Corporate body"),
-          (UnincorporatedBody, "Unincorporated body")
-        ) foreach {
+        types foreach {
           case (t, str) => Json.fromJson[OrganisationType](JsString(str)) mustBe JsSuccess(t)
+        }
+      }
+    }
+
+    "serialised" must {
+      "write the correct values" in {
+        types foreach {
+          case (t, str) => Json.toJson(t) mustBe JsString(str)
         }
       }
     }


### PR DESCRIPTION
This PR implements the main models on the EMTP side for the new API 1b, to fetch the company name. The models don't represent the entire response from 1b, just the subset of information we'll need in order to get the company name for the front-end.

I've also put in the ETMP connector and a working controller.