### PR TITLE
Updated microservice-bootstrap library version

### DIFF
--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -11,7 +11,7 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val microserviceBootstrapVersion = "6.11.0"
+  private val microserviceBootstrapVersion = "6.13.0"
   private val playUrlBindersVersion = "2.1.0"
   private val domainVersion = "5.0.0"
   private val playReactivemongoVersion = "5.2.0"


### PR DESCRIPTION
This is because it was out of date according to the Tax Service Catalogue