### PR TITLE
Added a guard to previous name details

### DIFF
--- a/app/models/des/responsiblepeople/PreviousNameDetails.scala
+++ b/app/models/des/responsiblepeople/PreviousNameDetails.scala
@@ -32,7 +32,7 @@ object PreviousNameDetails {
 
   def from(person: ResponsiblePeople): Option[PreviousNameDetails] = {
     (person.legalName, person.legalNameChangeDate) match {
-      case (Some(name), date) => Some(PreviousNameDetails(true, name, date.map(_.toString)))
+      case (Some(name), date) if name.hasPreviousName => Some(PreviousNameDetails(true, name, date.map(_.toString)))
       case _ => Some(PreviousNameDetails(false, None, None))
     }
   }

--- a/test/models/des/responsiblepeople/PreviousNameDetailsSpec.scala
+++ b/test/models/des/responsiblepeople/PreviousNameDetailsSpec.scala
@@ -17,6 +17,7 @@
 package models.des.responsiblepeople
 
 import models.ResponsiblePeopleSection
+import models.fe.responsiblepeople.{PreviousName, ResponsiblePeople}
 import org.scalatestplus.play.PlaySpec
 
 class PreviousNameDetailsSpec extends PlaySpec {
@@ -26,6 +27,12 @@ class PreviousNameDetailsSpec extends PlaySpec {
       // scalastyle:off magic.number
       PreviousNameDetails.from(ResponsiblePeopleSection.model.get.head) mustBe
         Some(PreviousNameDetails(true, Some(PersonName(Some("fname"), Some("mname"), Some("lname"))), Some("1990-02-24")))
+    }
+
+    "successfully convert a person without a previous name" in {
+      val person = ResponsiblePeople(legalName = Some(PreviousName(hasPreviousName = false, None, None, None)))
+
+      PreviousNameDetails.from(person) mustBe Some(PreviousNameDetails(false, None, None, None))
     }
   }
 }


### PR DESCRIPTION
This is to resolve an issue where data is being transmitted from the frontend with no legal name, but is being forwarded on in error as if a name has been supplied.

The actual name is blank, but the data suggests that there should be a name present. We suspect this is currently breaking API 5 calls into ETMP.