### PR TITLE
AMLS-3278: API 6 not sending correct status for unchanged responsible person

### DIFF
--- a/app/models/des/responsiblepeople/RPExtra.scala
+++ b/app/models/des/responsiblepeople/RPExtra.scala
@@ -20,7 +20,8 @@ import models.des.StringOrInt
 import models.fe.responsiblepeople.ResponsiblePeople
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
-import play.api.libs.json.{Json, _}
+import play.api.libs.json._
+import utils.StatusConstants
 
 case class RPExtra(
                     lineId: Option[StringOrInt] = None,
@@ -53,10 +54,17 @@ object RPExtra {
         (__ \ "retest").writeNullable[String] and
         (__ \ "testResult").writeNullable[String] and
         (__ \ "testDate").writeNullable[String]
-      ) (unlift(RPExtra.unapply _))
+      ) (unlift(RPExtra.unapply))
   }
 
   implicit def conv(rp: ResponsiblePeople): RPExtra = {
-    RPExtra(rp.lineId.fold[Option[StringOrInt]](None)(x => Some(StringOrInt(x.toString))), None, rp.status, None, None, None, None)
+    RPExtra(
+      rp.lineId.fold[Option[StringOrInt]](None)(x => Some(StringOrInt(x.toString))),
+      None,
+      rp.lineId.fold[Option[String]](None)(_ => if(rp.hasChanged) Some(StatusConstants.Updated) else Some(StatusConstants.Unchanged)),
+      None,
+      None,
+      None,
+      None)
   }
 }

--- a/app/models/fe/responsiblepeople/ResponsiblePeople.scala
+++ b/app/models/fe/responsiblepeople/ResponsiblePeople.scala
@@ -38,7 +38,8 @@ case class ResponsiblePeople(
                               training: Option[Training] = None,
                               hasAlreadyPassedFitAndProper: Option[Boolean] = None,
                               lineId: Option[Int] = None,
-                              status: Option[String] = None
+                              status: Option[String] = None,
+                              hasChanged: Boolean = false
                             )
 
 object ResponsiblePeople {

--- a/app/utils/ResponsiblePeopleUpdateHelper.scala
+++ b/app/utils/ResponsiblePeopleUpdateHelper.scala
@@ -41,8 +41,6 @@ trait ResponsiblePeopleUpdateHelper {
 
     val desResponsiblePeople = desRp.copy(extra = desRPExtra)
 
-    println(s"${Console.BLUE}${desResponsiblePeople.extra.status}${Console.RESET}")
-
     val updatedStatus = desResponsiblePeople.extra.status.getOrElse(
       if (desResponsiblePeople.equals(viewRp)) {
       StatusConstants.Unchanged

--- a/app/utils/ResponsiblePeopleUpdateHelper.scala
+++ b/app/utils/ResponsiblePeopleUpdateHelper.scala
@@ -38,30 +38,34 @@ trait ResponsiblePeopleUpdateHelper {
       testResult = viewRp.extra.testResult,
       testDate = viewRp.extra.testDate
     )
+
     val desResponsiblePeople = desRp.copy(extra = desRPExtra)
 
-    val updatedStatus = desResponsiblePeople.extra.status match {
-      case Some(StatusConstants.Deleted) => StatusConstants.Deleted
-      case _ => desResponsiblePeople.equals(viewRp) match {
-        case true => StatusConstants.Unchanged
-        case false => StatusConstants.Updated
-      }
-    }
+    println(s"${Console.BLUE}${desResponsiblePeople.extra.status}${Console.RESET}")
+
+    val updatedStatus = desResponsiblePeople.extra.status.getOrElse(
+      if (desResponsiblePeople.equals(viewRp)) {
+      StatusConstants.Unchanged
+    } else {
+      StatusConstants.Updated
+    })
 
     val statusExtraField = desResponsiblePeople.extra.copy(status = Some(updatedStatus))
-
     val updatedStatusRp = desResponsiblePeople.copy(extra = statusExtraField)
+
     if (AmlsConfig.release7) {
       updatedStatusRp.copy(nameDetails = updatedStatusRp.nameDetails map {
-        nd => nd.copy(previousNameDetails = nd.previousNameDetails map {
-          pnd => pnd.copy(dateChangeFlag = Some(pnd.dateOfChange != {
-            for {
-              nameDetails <- viewRp.nameDetails
-              previousNameDetails <- nameDetails.previousNameDetails
-              prevDateOfChange <- previousNameDetails.dateOfChange
-            } yield prevDateOfChange
-          }))
-        })
+        nd =>
+          nd.copy(previousNameDetails = nd.previousNameDetails map {
+            pnd =>
+              pnd.copy(dateChangeFlag = Some(pnd.dateOfChange != {
+                for {
+                  nameDetails <- viewRp.nameDetails
+                  previousNameDetails <- nameDetails.previousNameDetails
+                  prevDateOfChange <- previousNameDetails.dateOfChange
+                } yield prevDateOfChange
+              }))
+          })
       },
         dateChangeFlag = Some(updatedStatusRp.startDate !=
           viewRp.startDate
@@ -80,9 +84,10 @@ trait ResponsiblePeopleUpdateHelper {
         val rpWithAddedStatus = withoutLineIds.map(rp => rp.copy(extra = RPExtra(status = Some(StatusConstants.Added))))
         if (AmlsConfig.release7) {
           val rpWithDateChangeFlags = rpWithAddedStatus.map(rp => rp.copy(nameDetails = rp.nameDetails map {
-            nds => nds.copy(previousNameDetails = nds.previousNameDetails map {
-              pnd => pnd.copy(dateChangeFlag = Some(false))
-            })
+            nds =>
+              nds.copy(previousNameDetails = nds.previousNameDetails map {
+                pnd => pnd.copy(dateChangeFlag = Some(false))
+              })
           }, dateChangeFlag = Some(false)))
           rpWithLineIds ++ rpWithDateChangeFlags
         } else {

--- a/test/models/DefaultDesValues.scala
+++ b/test/models/DefaultDesValues.scala
@@ -33,6 +33,7 @@ import models.des.responsiblepeople.{Address => RPAddress, _}
 import models.des.tradingpremises.{Asp => TPAsp, _}
 import models.des.asp._
 import org.joda.time.LocalDate
+import utils.StatusConstants
 
 object DefaultDesValues {
 
@@ -172,6 +173,7 @@ object DefaultDesValues {
     RPExtra()
   )
   ))
+
   val ResponsiblePersonsSectionForRelease7 = Some(Seq(ResponsiblePersons(
     nameDtls,
     nationalDtls,

--- a/test/models/DefaultFEValues.scala
+++ b/test/models/DefaultFEValues.scala
@@ -446,8 +446,7 @@ object ResponsiblePeopleSection {
       Some(ExperienceTrainingNo),
       Some(TrainingYes("TrainingDetails")),
       Some(false),
-      Some(333333),
-      Some("added")),
+      Some(333333)),
 
     ResponsiblePeople(
       Some(PersonName("bbbbbbbbbbbb", Some("bbbbbbbbbbb"), "bbbbbbbbbbb")),
@@ -466,7 +465,7 @@ object ResponsiblePeopleSection {
       Some(ExperienceTrainingYes("bbbbbbbbbb")),
       Some(TrainingNo),
       Some(true),
-      Some(222222), Some("added")
+      Some(222222)
     )))
 }
 

--- a/test/models/des/DesConstants.scala
+++ b/test/models/des/DesConstants.scala
@@ -1766,7 +1766,7 @@ object DesConstants {
       Some(today),
       None,
       Some(MsbOrTcsp(false)),
-      RPExtra(Some(StringOrInt(333333)), None, Some("added"), None, None, None)
+      RPExtra(Some(StringOrInt(333333)), None, None, None, None, None)
     ),
     ResponsiblePersons(
       Some(NameDetails(
@@ -1813,7 +1813,7 @@ object DesConstants {
       Some(today),
       None,
       Some(MsbOrTcsp(true)),
-      RPExtra(Some(StringOrInt(222222)), None, Some("added"), None, None, None)
+      RPExtra(Some(StringOrInt(222222)), None, None, None, None, None)
     )
   )
 
@@ -1881,7 +1881,7 @@ object DesConstants {
       Some(today),
       None,
       Some(MsbOrTcsp(false)),
-      RPExtra(Some(StringOrInt("333333")), None, Some("added"), None, None, None)
+      RPExtra(Some(StringOrInt("333333")), None, Some(StatusConstants.Unchanged), None, None, None)
     ),
     ResponsiblePersons(
       Some(NameDetails(
@@ -1928,7 +1928,7 @@ object DesConstants {
       Some(today),
       None,
       Some(MsbOrTcsp(true)),
-      RPExtra(Some(StringOrInt("222222")), None, Some("added"), None, None, None)
+      RPExtra(Some(StringOrInt("222222")), None, Some(StatusConstants.Unchanged), None, None, None)
     )
   )
 
@@ -1996,7 +1996,7 @@ object DesConstants {
       Some(today),
       None,
       Some(MsbOrTcsp(false)),
-      RPExtra(Some(StringOrInt("333333")), None, Some("added"), None, None, None)
+      RPExtra(Some(StringOrInt("333333")), None, Some(StatusConstants.Unchanged), None, None, None)
     ),
     ResponsiblePersons(
       Some(NameDetails(
@@ -2043,7 +2043,7 @@ object DesConstants {
       Some(today),
       None,
       Some(MsbOrTcsp(true)),
-      RPExtra(Some(StringOrInt("222222")), None, Some("added"), None, None, None)
+      RPExtra(Some(StringOrInt("222222")), None, Some(StatusConstants.Unchanged), None, None, None)
     )
   )
 

--- a/test/models/fe/responsiblepeople/ResponsiblePeopleSpec.scala
+++ b/test/models/fe/responsiblepeople/ResponsiblePeopleSpec.scala
@@ -22,6 +22,7 @@ import org.joda.time.LocalDate
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
+import utils.StatusConstants
 
 
 class ResponsiblePeopleSpec extends PlaySpec with MockitoSugar with ResponsiblePeopleValues {
@@ -94,8 +95,7 @@ trait ResponsiblePeopleValues {
         Some(ExperienceTrainingNo),
         Some(TrainingYes("TrainingDetails")),
         Some(false),
-        Some(333333),
-        Some("added")
+        Some(333333)
       ),
 
       ResponsiblePeople(
@@ -114,13 +114,12 @@ trait ResponsiblePeopleValues {
         Some(ExperienceTrainingYes("bbbbbbbbbb")),
         Some(TrainingNo),
         Some(true),
-        Some(222222), Some("added")
+        Some(222222)
       )))
 
   }
 
   object NewValues {
-
     private val residenceYear = 1990
     private val residenceMonth = 2
     private val residenceDay = 24
@@ -234,6 +233,7 @@ trait ResponsiblePeopleValues {
     "training" -> Json.obj(
       "training" -> true,
       "information" -> "test"
-    )
+    ),
+    "hasChanged" -> false
   )
 }


### PR DESCRIPTION
The primary change here lies inside RPExtra, when it converts from frontend to backend. During the conversion, if the responsible person has a lineID then it sets the `status` field to `Updated` or `Unchanged` depending on the value of the frontend `hasChanged` flag (which is now being read from the Json being sent from the frontend.

Then, inside the conversion method, the status is simply passed through if it's available. If not, then it falls back to the previous strategy of comparing the converted DES model to that from the API 5 call.

Specs have been updated with more correct statuses, as some of them didn't reflect real-world values and were breaking tests.