### PR TITLE
AMLS-3451: Fee collection index update

### DIFF
--- a/app/modules/Module.scala
+++ b/app/modules/Module.scala
@@ -16,11 +16,10 @@
 
 package modules
 
-import javax.inject.Singleton
-
 import com.google.inject.{AbstractModule, Provides}
 import config.{MicroserviceAuditConnector, WSHttp}
 import connectors._
+import javax.inject.Singleton
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.DefaultDB
 import uk.gov.hmrc.http.{CorePost, CorePut}

--- a/app/repositories/FeesRepository.scala
+++ b/app/repositories/FeesRepository.scala
@@ -16,53 +16,37 @@
 
 package repositories
 
-import java.util.concurrent.TimeUnit
-
 import javax.inject.{Inject, Singleton}
 import models.Fees
 import play.api.Logger
 import play.api.libs.json.Json
 import play.modules.reactivemongo.MongoDbConnection
 import reactivemongo.api.commands.Command
-import reactivemongo.api.{BSONSerializationPack, DefaultDB}
 import reactivemongo.api.indexes.{Index, IndexType}
-import reactivemongo.bson.{BSONArray, BSONDocument, BSONObjectID}
-import uk.gov.hmrc.mongo.{ReactiveRepository, Repository}
+import reactivemongo.api.{BSONSerializationPack, DefaultDB}
 import reactivemongo.bson.DefaultBSONHandlers._
+import reactivemongo.bson.{BSONDocument, BSONObjectID}
+import uk.gov.hmrc.mongo.{ReactiveRepository, Repository}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class IndexUpdater @Inject()(implicit mongo: () => DefaultDB) extends ReactiveRepository[Fees, BSONObjectID]("fees", mongo, Fees.format) {
 
-  private lazy val feeResponseIndex = Index(Seq("createdAt" -> IndexType.Ascending),
-    name = Some("feeResponseExpiry"),
-    options = BSONDocument("expireAfterSeconds" -> 31536000))
-
-  def commandResult()(implicit ec: ExecutionContext): Future[BSONDocument] = {
-    //db.runCommand( {"collMod": "fees" , "index": { "keyPattern": {"createdAt" : 1} , "expireAfterSeconds": 31536000 }})
+  private def commandResult()(implicit ec: ExecutionContext): Future[BSONDocument] = {
     val commandDoc = BSONDocument(
       "collMod" -> "fees",
       "index" -> BSONDocument("keyPattern" -> BSONDocument("createdAt" -> 1), "expireAfterSeconds" -> 31536000)
     )
 
-    println(s">>>>>>>>>>>>>>>>>>>>>>>>>  About to run index update ${BSONDocument.pretty(commandDoc)}")
-
     val runner: Command.CommandWithPackRunner[BSONSerializationPack.type] = Command.run(BSONSerializationPack)
 
-    val stuff = runner.apply(collection.db, runner.rawCommand(commandDoc)).one[BSONDocument]
-
-    println(">>>>>>>>>>>>>>>>>>>>>>>>>  index update run")
-
-    stuff
+    runner.apply(collection.db, runner.rawCommand(commandDoc)).one[BSONDocument]
   }
 
-  def update = commandResult()
+  def update: Future[BSONDocument] = commandResult()
 }
-import scala.concurrent.{Await, ExecutionContext, Future, duration}
-import scala.util.{Failure, Success}
 
 trait FeesRepository extends Repository[Fees, BSONObjectID] {
 
@@ -83,8 +67,6 @@ class FeesMongoRepository()(implicit mongo: () => DefaultDB) extends ReactiveRep
     name = Some("amlsRefNumber"))
 
   override def indexes: Seq[Index] = {
-    //REMOVE LINE BELOW AFTER 1 DEPLOYMENT
-//    Await.result(collection.indexesManager.drop("FeeResponseExpiry"), Duration(30, TimeUnit.SECONDS))
     Seq(feeResponseIndex, amlsRefNumberIndex)
   }
 

--- a/test/controllers/SubscriptionViewControllerSpec.scala
+++ b/test/controllers/SubscriptionViewControllerSpec.scala
@@ -33,6 +33,8 @@ import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.Json
 import play.api.test.{FakeApplication, FakeRequest}
 import play.api.test.Helpers._
+import reactivemongo.bson.BSONDocument
+import repositories.IndexUpdater
 import utils.IterateeHelpers
 
 import scala.concurrent.Future
@@ -44,13 +46,18 @@ class SubscriptionViewControllerSpec
     with IntegrationPatience
     with IterateeHelpers
     with OneAppPerSuite
-    with AmlsReferenceNumberGenerator{
+    with AmlsReferenceNumberGenerator {
 
   implicit override lazy val app = FakeApplication(additionalConfiguration = Map("microservice.services.feature-toggle.release7" -> false))
 
   object SubscriptionViewController extends SubscriptionViewController {
     override val connector = mock[ViewDESConnector]
+    override val indexUpdater = mock[IndexUpdater]
   }
+
+  when {
+    SubscriptionViewController.indexUpdater.update
+  } thenReturn Future.successful(mock[BSONDocument])
 
   val request = FakeRequest()
     .withHeaders(CONTENT_TYPE -> "application/json")
@@ -128,8 +135,13 @@ class SubscriptionViewControllerSpecRelease7
 
   object SubscriptionViewController extends SubscriptionViewController {
     override val connector = mock[ViewDESConnector]
+    override val indexUpdater = mock[IndexUpdater]
   }
 
+  when {
+    SubscriptionViewController.indexUpdater.update
+  } thenReturn Future.successful(mock[BSONDocument])
+  
   val agentDetails = DesConstants.testTradingPremisesAPI5.agentBusinessPremises.fold[Option[Seq[AgentDetails]]](None) {
     x =>
       x.agentDetails match {


### PR DESCRIPTION
* `feeResponseExpiry` has has its TTL updated to 1 year (from 30 days)
* added index for `amlsReferenceNumber` field

Indexes are updated on first call to API 5 (subscription view)