### PR TITLE
AMLS-3766 Altered logic for when Supervision returns 'no' by default

### DIFF
--- a/app/connectors/DESConnector.scala
+++ b/app/connectors/DESConnector.scala
@@ -47,7 +47,6 @@ trait DESConnector extends HttpResponseHelper {
 
   private[connectors] def fullUrl: String
 
-
   val requestUrl = "anti-money-laundering/subscription"
 
   protected def desHeaderCarrier(implicit hc: HeaderCarrier) = {

--- a/app/models/fe/SubscriptionView.scala
+++ b/app/models/fe/SubscriptionView.scala
@@ -72,8 +72,9 @@ object SubscriptionView {
       aspSection = desView,
       msbSection = desView,
       hvdSection = desView,
-      supervisionSection = Supervision.convertFrom(desView.aspOrTcsp)
+      supervisionSection = Supervision.convertFrom(desView.aspOrTcsp, desView.businessActivities.mlrActivitiesAppliedFor)
     )
+
     if (view.businessMatchingSection.activities.businessActivities.exists(act => act == models.fe.businessmatching.MoneyServiceBusiness || act == TrustAndCompanyServices)) {
       view.copy(responsiblePeopleSection = view.responsiblePeopleSection match {
         case None => None
@@ -87,6 +88,7 @@ object SubscriptionView {
         }
       })
     } else view
+
   }
 
 }

--- a/app/models/fe/supervision/Supervision.scala
+++ b/app/models/fe/supervision/Supervision.scala
@@ -30,6 +30,20 @@ object Supervision {
 
   implicit val formats = Json.format[Supervision]
 
+  /**
+    * Converts from the ETMP 'supervision' model to our frontend model.
+    *
+    * This mostly converts from the ETMP model to the frontend model for Supervision.
+    *
+    * The ETMP model may not be available if the user has answered 'no' to all of the Supervision
+    * questions on the frontend. If maybeAspOrTcsp is None, and the submission activities include TCSP or ASP, then
+    * we know that the user must have selected 'no' for all of the Supervision questions.
+    * Otherwise, either the converted model should be returned, or None if there's no Supervision data to convert from
+    * and the activites don't include either ASP or TCSP.
+    * @param maybeAspOrTcsp The ETMP supervision model
+    * @param maybeActivities The activities that have been applied for as part of the submission data
+    * @return The Supervision model after having been converted from ETMP's supervision model
+    */
   def convertFrom(maybeAspOrTcsp: Option[AspOrTcsp], maybeActivities: Option[MlrActivitiesAppliedFor]): Option[Supervision] =
     (maybeAspOrTcsp, maybeActivities) match {
       case (None, Some(activities)) if activities.tcsp || activities.asp =>

--- a/app/models/fe/supervision/Supervision.scala
+++ b/app/models/fe/supervision/Supervision.scala
@@ -16,6 +16,7 @@
 
 package models.fe.supervision
 
+import models.des.businessactivities.MlrActivitiesAppliedFor
 import models.des.supervision.AspOrTcsp
 
 case class Supervision(anotherBody: Option[AnotherBody] = None,
@@ -29,14 +30,20 @@ object Supervision {
 
   implicit val formats = Json.format[Supervision]
 
-  def convertFrom(maybeAspOrTcsp: Option[AspOrTcsp]) : Option[Supervision] = {
-    maybeAspOrTcsp map { aspOrTcsp => Supervision(
-        AnotherBody.conv(aspOrTcsp.supervisionDetails),
-        ProfessionalBodyMember.conv(aspOrTcsp.professionalBodyDetails),
-        BusinessTypes.conv(aspOrTcsp.professionalBodyDetails),
-        ProfessionalBody.conv(aspOrTcsp.professionalBodyDetails)
-      )
+  def convertFrom(maybeAspOrTcsp: Option[AspOrTcsp], maybeActivities: Option[MlrActivitiesAppliedFor]): Option[Supervision] =
+    (maybeAspOrTcsp, maybeActivities) match {
+      case (None, Some(activities)) if activities.tcsp || activities.asp =>
+        Some(Supervision(Some(AnotherBodyNo), Some(ProfessionalBodyMemberNo), None, Some(ProfessionalBodyNo)))
+
+      case (Some(aspOrTcsp), _) =>
+        Some(Supervision(
+          AnotherBody.conv(aspOrTcsp.supervisionDetails),
+          ProfessionalBodyMember.conv(aspOrTcsp.professionalBodyDetails),
+          BusinessTypes.conv(aspOrTcsp.professionalBodyDetails),
+          ProfessionalBody.conv(aspOrTcsp.professionalBodyDetails)
+        ))
+
+      case _ => None
     }
-  }
 
 }

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -33,17 +33,18 @@ private object AppDependencies {
     lazy val test : Seq[ModuleID] = ???
   }
 
-  private val scalatestVersion = "2.2.6"
-  private val scalatestPlusPlayVersion = "1.5.1"
+  private val scalatestVersion = "3.0.4"
+  private val scalatestPlusPlayVersion = "2.0.1"
   private val pegdownVersion = "1.6.0"
   private val hmrctestVersion = "2.4.0"
+  private val scalacheckVersion = "1.13.4"
 
   object Test {
     def apply() = new TestDependencies {
       override lazy val test = Seq(
         "org.scalatest" %% "scalatest" % scalatestVersion % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % scalatestPlusPlayVersion % scope,
-        "org.scalacheck" %% "scalacheck" % "1.12.5" % scope,
+        "org.scalacheck" %% "scalacheck" % scalacheckVersion % scope,
         "uk.gov.hmrc" %% "hmrctest" % hmrctestVersion % scope,
         "org.pegdown" % "pegdown" % pegdownVersion % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,

--- a/test/models/fe/moneyservicebusiness/FundsTransferSpec.scala
+++ b/test/models/fe/moneyservicebusiness/FundsTransferSpec.scala
@@ -20,7 +20,8 @@ import org.scalatestplus.play.PlaySpec
 
 class FundsTransferSpec extends PlaySpec {
   "FundsTransfer" must {
-    FundsTransfer.convMsbAll(None) must be(None)
-
+    "convert the model correctly" in {
+      FundsTransfer.convMsbAll(None) must be(None)
+    }
   }
 }


### PR DESCRIPTION
Now, the logic to determine whether all of the Supervision fields are pre-filled with 'no' looks at whether or not the activities list includes ASP and/or TCSP. If not, the None is returned.

This is because the data supplier will return an empty node for `aspOrTcsp` if the user has filled in 'no' to all of those questions on the frontend.

This commit also contains some re-writing of the Supervision spec, which takes a property-based testing approach. Version numbers for scalatest, scalacheck and scalaTestPlusPlay have also been bumped to the latest versions.

The JSON specs have also been removed as they are somewhat redundant.