### PR TITLE
AMLS-4024 Fixes incomplete Business Activities on load

### DIFF
--- a/app/models/fe/SubscriptionView.scala
+++ b/app/models/fe/SubscriptionView.scala
@@ -20,7 +20,7 @@ import models.fe.aboutthebusiness.AboutTheBusiness
 import models.fe.asp.Asp
 import models.fe.bankdetails.BankDetails
 import models.fe.businessactivities.BusinessActivities
-import models.fe.businessmatching.{BusinessMatching, TrustAndCompanyServices}
+import models.fe.businessmatching.{BusinessActivity, BusinessMatching, TrustAndCompanyServices, MoneyServiceBusiness => MSBActivity}
 import models.fe.declaration.AddPerson
 import models.fe.estateagentbusiness.EstateAgentBusiness
 import models.fe.hvd.Hvd
@@ -66,7 +66,7 @@ object SubscriptionView {
       aboutTheBusinessSection = desView,
       bankDetailsSection = desView.bankAccountDetails,
       aboutYouSection = desView.extraFields.filingIndividual,
-      businessActivitiesSection = desView.businessActivities.all,
+      businessActivitiesSection = BusinessActivities.convertBusinessActivities(desView.businessActivities.all),
       responsiblePeopleSection = desView.responsiblePersons,
       tcspSection = desView,
       aspSection = desView,
@@ -75,20 +75,23 @@ object SubscriptionView {
       supervisionSection = Supervision.convertFrom(desView.aspOrTcsp, desView.businessActivities.mlrActivitiesAppliedFor)
     )
 
-    if (view.businessMatchingSection.activities.businessActivities.exists(act => act == models.fe.businessmatching.MoneyServiceBusiness || act == TrustAndCompanyServices)) {
+    val isMsbOrTcsp = (activity: BusinessActivity) => activity == MSBActivity || activity == TrustAndCompanyServices
+
+    if (view.businessMatchingSection.activities.businessActivities.exists(isMsbOrTcsp)) {
       view.copy(responsiblePeopleSection = view.responsiblePeopleSection match {
         case None => None
-        case Some(rpSeq) => {
+
+        case Some(rpSeq) =>
           Some(rpSeq.map {
             rp => rp.hasAlreadyPassedFitAndProper match {
               case Some(a) => rp
               case None => rp.copy(hasAlreadyPassedFitAndProper = Some(false))
             }
           })
-        }
       })
-    } else view
 
+    } else {
+      view
+    }
   }
-
 }

--- a/app/models/fe/SubscriptionView.scala
+++ b/app/models/fe/SubscriptionView.scala
@@ -66,7 +66,10 @@ object SubscriptionView {
       aboutTheBusinessSection = desView,
       bankDetailsSection = desView.bankAccountDetails,
       aboutYouSection = desView.extraFields.filingIndividual,
-      businessActivitiesSection = BusinessActivities.convertBusinessActivities(desView.businessActivities.all),
+      businessActivitiesSection = BusinessActivities.convertBusinessActivities(
+        desView.businessActivities.all,
+        desView.businessActivities.mlrActivitiesAppliedFor
+      ),
       responsiblePeopleSection = desView.responsiblePersons,
       tcspSection = desView,
       aspSection = desView,

--- a/app/models/fe/businessactivities/AccountantForAMLSRegulations.scala
+++ b/app/models/fe/businessactivities/AccountantForAMLSRegulations.scala
@@ -16,7 +16,7 @@
 
 package models.fe.businessactivities
 
-import models.des.businessactivities.BusinessActivitiesAll
+import models.des.businessactivities.{BusinessActivitiesAll, MlrActivitiesAppliedFor, MlrAdvisor}
 import play.api.libs.json.Json
 
 case class AccountantForAMLSRegulations(accountantForAMLSRegulations: Boolean)
@@ -25,12 +25,21 @@ object AccountantForAMLSRegulations {
 
   implicit val formats = Json.format[AccountantForAMLSRegulations]
 
-  def convertAccountant(desBA: Option[BusinessActivitiesAll]): Option[AccountantForAMLSRegulations] = {
-    for {
-      dba <- desBA
-      mlrAdvisor <- dba.mlrAdvisor
-    } yield {
-      AccountantForAMLSRegulations(mlrAdvisor.doYouHaveMlrAdvisor)
+  /**
+    * Converts an MLR Advisor instance into AccountantForAMLSRegulations.
+    * There is some logic here to ensure that the correct data is returned if no advisor data is supplied, which is a real scenario
+    * if the application says that the business does ASP, but the user has answered 'no' to the Business Activities question 'Does your business receive advice...?' on
+    * the frontend. In this case, ETMP will not return any data for this question. In that case, if the business is not an ASP and there is no data
+    * for that question, then it can be assumed that the user answered 'no'.
+    * If the business IS an ASP, then None should be returned for this question (in this scenario, the user is never asked to complete that question).
+    * @param maybeAdvisor The MLR Advisor object to convert
+    * @param maybeActivities The MLR activities supplied as part of the application
+    * @return
+    */
+  def convertAccountant(maybeAdvisor: Option[MlrAdvisor], maybeActivities: Option[MlrActivitiesAppliedFor]): Option[AccountantForAMLSRegulations] =
+    (maybeAdvisor, maybeActivities) match {
+      case (None, Some(activities)) if !activities.asp => Some(AccountantForAMLSRegulations(false))
+      case (None, Some(activities)) if activities.asp => None
+      case (Some(advisor), _) => Some(AccountantForAMLSRegulations(advisor.doYouHaveMlrAdvisor))
     }
-  }
 }

--- a/app/models/fe/businessactivities/BusinessActivities.scala
+++ b/app/models/fe/businessactivities/BusinessActivities.scala
@@ -16,7 +16,7 @@
 
 package models.fe.businessactivities
 
-import models.des.businessactivities.{BusinessActivitiesAll, MlrAdvisor}
+import models.des.businessactivities.{BusinessActivitiesAll, MlrActivitiesAppliedFor, MlrAdvisor}
 
 case class BusinessActivities(
                                involvedInOther: Option[InvolvedInOther] = None,
@@ -78,7 +78,7 @@ object BusinessActivities {
       }
   }
 
-  def convertBusinessActivities(desBA: Option[BusinessActivitiesAll]): BusinessActivities = {
+  def convertBusinessActivities(desBA: Option[BusinessActivitiesAll], mlrActivities: Option[MlrActivitiesAppliedFor]): BusinessActivities = {
 
     desBA.map { dba =>
       BusinessActivities(
@@ -89,7 +89,7 @@ object BusinessActivities {
         transactionRecord = TransactionTypes.convertRecordsKept(dba),
         customersOutsideUK = CustomersOutsideUK.conv(dba),
         ncaRegistered = Some(NCARegistered(dba.nationalCrimeAgencyRegistered)),
-        accountantForAMLSRegulations = AccountantForAMLSRegulations.convertAccountant(desBA),
+        accountantForAMLSRegulations = AccountantForAMLSRegulations.convertAccountant(desBA.fold[Option[MlrAdvisor]](None)(_.mlrAdvisor), mlrActivities),
         identifySuspiciousActivity = Some(IdentifySuspiciousActivity(dba.suspiciousActivityGuidance)),
         riskAssessmentPolicy = RiskAssessmentPolicy.conv(dba.formalRiskAssessmentDetails),
         howManyEmployees = HowManyEmployees.conv(dba),

--- a/app/models/fe/businessactivities/BusinessActivities.scala
+++ b/app/models/fe/businessactivities/BusinessActivities.scala
@@ -78,9 +78,9 @@ object BusinessActivities {
       }
   }
 
-  implicit def conv(desBA: Option[BusinessActivitiesAll]): BusinessActivities = {
+  def convertBusinessActivities(desBA: Option[BusinessActivitiesAll]): BusinessActivities = {
 
-    val businessActivitiesOpt = desBA.map { dba =>
+    desBA.map { dba =>
       BusinessActivities(
         involvedInOther = InvolvedInOther.conv(dba.businessActivityDetails),
         expectedBusinessTurnover = ExpectedBusinessTurnover.conv(dba.businessActivityDetails),
@@ -97,8 +97,7 @@ object BusinessActivities {
         taxMatters = dba.mlrAdvisor flatMap { mlrAdvisor => TaxMatters.conv(mlrAdvisor.mlrAdvisorDetails) },
         transactionRecordTypes = TransactionTypes.convert(dba.auditableRecordsDetails)
       )
-    }
-    businessActivitiesOpt getOrElse BusinessActivities()
-  }
+    } getOrElse BusinessActivities()
 
+  }
 }

--- a/test/generators/supervision/BusinessActivityGenerators.scala
+++ b/test/generators/supervision/BusinessActivityGenerators.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generators.supervision
+
+import models.des.businessactivities.MlrActivitiesAppliedFor
+import org.joda.time.LocalDate
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
+
+trait BusinessActivityGenerators {
+  val activityGen: Gen[MlrActivitiesAppliedFor] = for {
+    msb <- arbitrary[Boolean]
+    hvd <- arbitrary[Boolean]
+    asp <- arbitrary[Boolean]
+    tcsp <- arbitrary[Boolean]
+    eab <- arbitrary[Boolean]
+    bpsp <- arbitrary[Boolean]
+    tditpsp <- arbitrary[Boolean]
+  } yield MlrActivitiesAppliedFor(msb, hvd, asp, tcsp, eab, bpsp, tditpsp)
+
+  implicit val arbitraryMlrActivities: Arbitrary[MlrActivitiesAppliedFor] = Arbitrary(activityGen.sample.get)
+  implicit val arbitraryLocalDate: Arbitrary[LocalDate] = Arbitrary(LocalDate.now())
+}

--- a/test/generators/supervision/SupervisionGenerators.scala
+++ b/test/generators/supervision/SupervisionGenerators.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generators.supervision
+
+import models.des.businessactivities.MlrActivitiesAppliedFor
+import models.des.supervision._
+import org.joda.time.LocalDate
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
+
+trait SupervisionGenerators {
+  val supervisorDetailsGen: Gen[SupervisorDetails] = for {
+    name <- arbitrary[String]
+    startDate <- Gen.const(LocalDate.now())
+    endDate <- Gen.const(LocalDate.now())
+    dateChange <- arbitrary[Boolean]
+    reason <- arbitrary[String]
+  } yield SupervisorDetails(name, startDate.toString("yyyy-MM-dd"), endDate.toString("yyyy-MM-dd"), Some(dateChange), reason)
+
+  val supervisionDetailsGen: Gen[SupervisionDetails] = for {
+    supervised <- arbitrary[Boolean]
+    supervisor <- supervisorDetailsGen
+  } yield SupervisionDetails(supervised, if (supervised) Some(supervisor) else None)
+
+  val memberOfProfessionalBodyGen: Gen[MemberOfProfessionalBody] = Gen.const(
+    MemberOfProfessionalBody(false, false, false, false, false, false, false, false, false, false, false, false, false, false, None)
+  )
+
+  val professionalBodyGen: Gen[ProfessionalBodyDetails] = for {
+    preWarned <- arbitrary[Boolean]
+    details <- arbitrary[String]
+    professionalBodyMember <- arbitrary[Boolean]
+    member <- Gen.const(ProfessionalBodyDesMember(professionalBodyMember, memberOfProfessionalBodyGen.sample))
+  } yield ProfessionalBodyDetails(preWarned, if (preWarned) Some(details) else None, Some(member))
+
+  val aspOrTcspGen: Gen[AspOrTcsp] = for {
+    details <- supervisionDetailsGen
+    professionalBody <- professionalBodyGen
+  } yield AspOrTcsp(Some(details), Some(professionalBody))
+
+  def withoutAspOrTcsp(model: MlrActivitiesAppliedFor): MlrActivitiesAppliedFor =
+    model.copy(asp = false, tcsp = false)
+
+  implicit val arbitraryAspOrTcsp: Arbitrary[AspOrTcsp] = Arbitrary(aspOrTcspGen)
+}

--- a/test/models/fe/businessactivities/BusinessActivitiesSpec.scala
+++ b/test/models/fe/businessactivities/BusinessActivitiesSpec.scala
@@ -161,7 +161,7 @@ class BusinessActivitiesSpec extends PlaySpec with MockitoSugar with OneAppPerSu
         Some(TransactionTypes(Set(Paper, DigitalSpreadsheet, DigitalSoftware("CommercialPackageName"))))
       )
 
-      BusinessActivities.conv(desModel) must be(feModel)
+      BusinessActivities.convertBusinessActivities(desModel) must be(feModel)
     }
 
     "convert des model to frontend successfully when business all don't have data" in {
@@ -170,7 +170,7 @@ class BusinessActivitiesSpec extends PlaySpec with MockitoSugar with OneAppPerSu
 
       val feModel = BusinessActivities(None,None,None,None,None,None,None,None,None,None,None,None)
 
-      BusinessActivities.conv(desModel) must be(feModel)
+      BusinessActivities.convertBusinessActivities(desModel) must be(feModel)
     }
   }
 

--- a/test/models/fe/businessactivities/BusinessActivitiesSpec.scala
+++ b/test/models/fe/businessactivities/BusinessActivitiesSpec.scala
@@ -161,7 +161,7 @@ class BusinessActivitiesSpec extends PlaySpec with MockitoSugar with OneAppPerSu
         Some(TransactionTypes(Set(Paper, DigitalSpreadsheet, DigitalSoftware("CommercialPackageName"))))
       )
 
-      BusinessActivities.convertBusinessActivities(desModel) must be(feModel)
+      BusinessActivities.convertBusinessActivities(desModel, None) must be(feModel)
     }
 
     "convert des model to frontend successfully when business all don't have data" in {
@@ -170,7 +170,7 @@ class BusinessActivitiesSpec extends PlaySpec with MockitoSugar with OneAppPerSu
 
       val feModel = BusinessActivities(None,None,None,None,None,None,None,None,None,None,None,None)
 
-      BusinessActivities.convertBusinessActivities(desModel) must be(feModel)
+      BusinessActivities.convertBusinessActivities(desModel, None) must be(feModel)
     }
   }
 


### PR DESCRIPTION
Similar to the Supervision issue, the data supplier does not return a value for `MLRAdvisor` in the case where the user has selected 'No' to the question 'Does your business receive advice..?' relating to whether or not they use an advisor for money laundering due diligence.

This PR attempts to fix the default value returned when this data is missing. It now checks the activities being applied for; if the data is missing and the business does not do Accountancy Services, then it can be assumed that the user answered 'no' to that question.

There is a [related PR in amls-stub](https://github.com/hmrc/amls-stub/pull/36) which can be used to verify the fix.