### PR TITLE
Defaulted the 'dateChangeFlag'

### DIFF
--- a/app/models/des/tradingpremises/AgentDetails.scala
+++ b/app/models/des/tradingpremises/AgentDetails.scala
@@ -119,7 +119,7 @@ object AgentDetails {
       },
       agentPremises = tradingPremises,
       startDate,
-      None,
+      Some(tradingPremises.whatDoesYourBusinessDoAtThisAddress.dateOfChange.isDefined),
       endDate,
       tradingPremises.status,
       tradingPremises.lineId,


### PR DESCRIPTION
This is causing an issue with acceptance tests when the data is being overridden by another file from stubs. This value is normally updated based on the line id's for trading premises, but in the case where an overriding JSON file is used, the line ids usually don't match up, so the value is never set.

The value for `dateChangeFlag` is defaulted to true or false depending on whether there is a value in the `dateOfChange` field.