### PR TITLE
Amls 4430 dob fix

### DIFF
--- a/app/models/des/responsiblepeople/NonUkResident.scala
+++ b/app/models/des/responsiblepeople/NonUkResident.scala
@@ -19,7 +19,7 @@ package models.des.responsiblepeople
 import models.fe.responsiblepeople.{NonUKResidence, _}
 import play.api.libs.json.Json
 
-case class NonUkResident(dateOfBirth: String,
+case class NonUkResident(dateOfBirth: Option[String] = None,
                          passportHeld: Boolean,
                          passportDetails: Option[PassportDetail]
                         )
@@ -32,11 +32,12 @@ object NonUkResident {
       rp.ukPassport flatMap {
         case UKPassportYes(num) => rt.isUKResidence match {
           case NonUKResidence =>
-            rp.dateOfBirth map { dob =>
-              IdDetail(
-                None, Some(NonUkResident(dob.dateOfBirth.toString, true, Some(PassportDetail(true, PassportNum(ukPassportNumber = Some(num))))))
-              )
-            }
+            //rp.dateOfBirth map { dob =>
+              Some(IdDetail(
+                None,
+                Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true, Some(PassportDetail(true, PassportNum(ukPassportNumber = Some(num))))))
+              ))
+            //}
         }
         case _ => None
       } getOrElse {
@@ -44,17 +45,17 @@ object NonUkResident {
           case (Some(NonUKPassportYes(num)), NonUKResidence) => {
             IdDetail(
               None,
-              rp.dateOfBirth map { dob =>
-                NonUkResident(dob.dateOfBirth.toString, true,
-                  Some(PassportDetail(false, PassportNum(nonUkPassportNumber = Some(num)))))
-              })
+              //rp.dateOfBirth map { dob =>
+                Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true,
+                  Some(PassportDetail(false, PassportNum(nonUkPassportNumber = Some(num)))))))
+              //})
           }
           case (Some(NoPassport) | None, NonUKResidence) => {
             IdDetail(
               None,
-              rp.dateOfBirth map { dob =>
-                NonUkResident(dob.dateOfBirth.toString, false, None)
-              })
+              //rp.dateOfBirth map { dob =>
+              Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, false, None)))
+              //})
           }
         }
       }

--- a/app/models/des/responsiblepeople/NonUkResident.scala
+++ b/app/models/des/responsiblepeople/NonUkResident.scala
@@ -34,7 +34,8 @@ object NonUkResident {
           case NonUKResidence =>
             Some(IdDetail(
               None,
-              Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true, Some(PassportDetail(true, PassportNum(ukPassportNumber = Some(num))))))
+              Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true,
+                Some(PassportDetail(true, PassportNum(ukPassportNumber = Some(num))))))
             ))
         }
         case _ => None

--- a/app/models/des/responsiblepeople/NonUkResident.scala
+++ b/app/models/des/responsiblepeople/NonUkResident.scala
@@ -32,12 +32,10 @@ object NonUkResident {
       rp.ukPassport flatMap {
         case UKPassportYes(num) => rt.isUKResidence match {
           case NonUKResidence =>
-            //rp.dateOfBirth map { dob =>
-              Some(IdDetail(
-                None,
-                Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true, Some(PassportDetail(true, PassportNum(ukPassportNumber = Some(num))))))
-              ))
-            //}
+            Some(IdDetail(
+              None,
+              Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true, Some(PassportDetail(true, PassportNum(ukPassportNumber = Some(num))))))
+            ))
         }
         case _ => None
       } getOrElse {
@@ -45,17 +43,13 @@ object NonUkResident {
           case (Some(NonUKPassportYes(num)), NonUKResidence) => {
             IdDetail(
               None,
-              //rp.dateOfBirth map { dob =>
-                Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true,
-                  Some(PassportDetail(false, PassportNum(nonUkPassportNumber = Some(num)))))))
-              //})
+              Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, true,
+                Some(PassportDetail(false, PassportNum(nonUkPassportNumber = Some(num)))))))
           }
           case (Some(NoPassport) | None, NonUKResidence) => {
             IdDetail(
               None,
-              //rp.dateOfBirth map { dob =>
               Some(NonUkResident(rp.dateOfBirth map { _.dateOfBirth.toString }, false, None)))
-              //})
           }
         }
       }

--- a/app/models/fe/responsiblepeople/DateOfBirth.scala
+++ b/app/models/fe/responsiblepeople/DateOfBirth.scala
@@ -33,18 +33,25 @@ object DateOfBirth {
       id <- nd.idDetails
     } yield id
 
-    /**
-      * TODO: This code isn't correct as if the non-uk resident does not have a date of birth, and for some reason it previously have a uk one, then it will default back to the
-      * new one, we will need to write a new test for this.
-      */
+    println("ACHI idDetail : " + idDetail)
 
-    idDetail.flatMap(idDetail =>
-        idDetail.nonUkResident map(_.dateOfBirth) match {
-          case Some(str) => Some(DateOfBirth(LocalDate.parse(str)))
-          case _ if AmlsConfig.phase2Changes => idDetail.dateOfBirth.map(ukDOB => DateOfBirth(LocalDate.parse(ukDOB)))
-          case _ => None
-      }
+    val nonUkDob = idDetail.flatMap(idDetail =>
+      idDetail.nonUkResident.flatMap(nonUkRes =>
+        nonUkRes.dateOfBirth
+      )
     )
-  }
 
+    val ukDob = idDetail.flatMap(idDetail =>
+      idDetail.dateOfBirth
+    )
+
+    println("ACHI uk : " + ukDob)
+    println("ACHI non uk: " + nonUkDob)
+
+    nonUkDob match {
+      case Some(x) => Some(DateOfBirth(LocalDate.parse(x.toString)))
+      case _ if AmlsConfig.phase2Changes => Some(DateOfBirth(LocalDate.parse(ukDob.toString)))
+      case _ => None
+    }
+  }
 }

--- a/app/models/fe/responsiblepeople/DateOfBirth.scala
+++ b/app/models/fe/responsiblepeople/DateOfBirth.scala
@@ -33,8 +33,6 @@ object DateOfBirth {
       id <- nd.idDetails
     } yield id
 
-    println("ACHI idDetail : " + idDetail)
-
     val nonUkDob = idDetail.flatMap(idDetail =>
       idDetail.nonUkResident.flatMap(nonUkRes =>
         nonUkRes.dateOfBirth
@@ -45,13 +43,12 @@ object DateOfBirth {
       idDetail.dateOfBirth
     )
 
-    println("ACHI uk : " + ukDob)
-    println("ACHI non uk: " + nonUkDob)
-
-    nonUkDob match {
-      case Some(x) => Some(DateOfBirth(LocalDate.parse(x.toString)))
-      case _ if AmlsConfig.phase2Changes => Some(DateOfBirth(LocalDate.parse(ukDob.toString)))
-      case _ => None
+    if(!ukDob.isEmpty && AmlsConfig.phase2Changes) {
+      Some(DateOfBirth(LocalDate.parse(ukDob.getOrElse(""))))
+    } else if (!nonUkDob.isEmpty) {
+      Some(DateOfBirth(LocalDate.parse(nonUkDob.getOrElse(""))))
+    } else {
+      None
     }
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -257,7 +257,7 @@ microservice {
     feature-toggle {
       release7 = true
       enrolment-store = true
-      phase-2-changes = true
+      phase-2-changes = false
     }
 
     pay-api {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -257,7 +257,7 @@ microservice {
     feature-toggle {
       release7 = true
       enrolment-store = true
-      phase-2-changes = false
+      phase-2-changes = true
     }
 
     pay-api {

--- a/test/models/des/DesConstants.scala
+++ b/test/models/des/DesConstants.scala
@@ -1501,7 +1501,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -1571,7 +1571,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -1639,7 +1639,7 @@ object DesConstants {
       Some(IdDetail(
         None,
         Some(NonUkResident(
-          "2001-01-01",
+          Some("2001-01-01"),
           true,
           Some(PassportDetail(
             true,
@@ -1721,7 +1721,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -1841,7 +1841,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -1962,7 +1962,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -2082,7 +2082,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -2197,7 +2197,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -2312,7 +2312,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -2459,7 +2459,7 @@ object DesConstants {
     Some(IdDetail(
       None,
       Some(NonUkResident(
-        "2001-01-01",
+        Some("2001-01-01"),
         true,
         Some(PassportDetail(
           true,
@@ -2597,7 +2597,7 @@ object DesConstants {
       Some(IdDetail(
         None,
         Some(NonUkResident(
-          "2001-01-01",
+          Some("2001-01-01"),
           true,
           Some(PassportDetail(
             true,
@@ -2848,7 +2848,7 @@ object DesConstants {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,

--- a/test/models/des/responsiblepeople/NationalityDetailsSpec.scala
+++ b/test/models/des/responsiblepeople/NationalityDetailsSpec.scala
@@ -47,7 +47,7 @@ class NationalityDetailsSpec extends PlaySpec with OneAppPerSuite {
                 dateOfBirth = Some(DateOfBirth(new LocalDate(1990, 2, 24)))
             )
             NationalityDetails.convert(rp) must be(Some(NationalityDetails(false,
-                Some(IdDetail(nonUkResident = Some(NonUkResident("1990-02-24", true, Some(PassportDetail(true, PassportNum(Some("AA111111A"), None))))))),
+                Some(IdDetail(nonUkResident = Some(NonUkResident(Some("1990-02-24"), true, Some(PassportDetail(true, PassportNum(Some("AA111111A"), None))))))),
                 rp.personResidenceType map { _.countryOfBirth },
                 rp.personResidenceType map { _.nationality })))
         }
@@ -81,7 +81,7 @@ class NationalityDetailsPhase2Spec extends PlaySpec with OneAppPerSuite {
                 dateOfBirth = Some(DateOfBirth(new LocalDate(1990, 2, 24)))
             )
             NationalityDetails.convert(rp) must be(Some(NationalityDetails(false,
-                Some(IdDetail(nonUkResident = Some(NonUkResident("1990-02-24", true, Some(PassportDetail(true, PassportNum(Some("AA111111A"), None))))))),
+                Some(IdDetail(nonUkResident = Some(NonUkResident(Some("1990-02-24"), true, Some(PassportDetail(true, PassportNum(Some("AA111111A"), None))))))),
                 rp.personResidenceType map { _.countryOfBirth },
                 rp.personResidenceType map { _.nationality })))
         }

--- a/test/models/des/responsiblepeople/NonUkResidentSpec.scala
+++ b/test/models/des/responsiblepeople/NonUkResidentSpec.scala
@@ -44,6 +44,16 @@ class NonUkResidentSpec extends PlaySpec {
         true, Some(PassportDetail(false, PassportNum(None, Some("1234612124646")))))))))
     }
 
+    "convert frontend model to des model for NonUKPassport with no DOB" in {
+      val rp = ResponsiblePeople(
+        personResidenceType = Some(PersonResidenceType(NonUKResidence, "GB", "GB")),
+        nonUKPassport = Some(NonUKPassportYes("1234612124646")),
+        dateOfBirth = None
+      )
+      NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident(None,
+        true, Some(PassportDetail(false, PassportNum(None, Some("1234612124646")))))))))
+    }
+
     "convert frontend model to des model for NoPassport" when {
       "nonUkPassport is NoPassport" in {
         val rp = ResponsiblePeople(

--- a/test/models/des/responsiblepeople/NonUkResidentSpec.scala
+++ b/test/models/des/responsiblepeople/NonUkResidentSpec.scala
@@ -30,7 +30,7 @@ class NonUkResidentSpec extends PlaySpec {
         ukPassport = Some(UKPassportYes("AA111111A")),
         dateOfBirth = Some(DateOfBirth(new LocalDate(1990, 2, 24)))
       )
-      NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident("1990-02-24",
+      NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident(Some("1990-02-24"),
         true, Some(PassportDetail(true, PassportNum(Some("AA111111A"), None))))))))
     }
 
@@ -40,7 +40,7 @@ class NonUkResidentSpec extends PlaySpec {
         nonUKPassport = Some(NonUKPassportYes("1234612124646")),
         dateOfBirth = Some(DateOfBirth(new LocalDate(1990, 2, 24)))
       )
-      NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident("1990-02-24",
+      NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident(Some("1990-02-24"),
         true, Some(PassportDetail(false, PassportNum(None, Some("1234612124646")))))))))
     }
 
@@ -52,7 +52,7 @@ class NonUkResidentSpec extends PlaySpec {
           dateOfBirth = Some(DateOfBirth(new LocalDate(1990, 2, 24)))
         )
 
-        NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident("1990-02-24", false, None)))))
+        NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident(Some("1990-02-24"), false, None)))))
       }
 
       "nonUkPassport is None" in {
@@ -62,7 +62,7 @@ class NonUkResidentSpec extends PlaySpec {
           dateOfBirth = Some(DateOfBirth(new LocalDate(1990, 2, 24)))
         )
 
-        NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident("1990-02-24", false, None)))))
+        NonUkResident.convert(rp) must be(Some(IdDetail(None, Some(NonUkResident(Some("1990-02-24"), false, None)))))
       }
     }
   }

--- a/test/models/fe/responsiblepeople/DateOfBirthSpec.scala
+++ b/test/models/fe/responsiblepeople/DateOfBirthSpec.scala
@@ -58,7 +58,7 @@ class DateOfBirthSpec extends PlaySpec with OneAppPerSuite {
           false,
           Some(IdDetail(
             nonUkResident = Some(NonUkResident(
-              "1990-03-23",false,None
+              Some("1990-03-23"),false,None
             ))
           )),None,None
         )),None,None,None,None,None,None,None,None,None,false,None,false,None,None,None,None,extra = RPExtra()
@@ -117,7 +117,7 @@ class DateOfBirthPhase2Spec extends PlaySpec with OneAppPerSuite {
           false,
           Some(IdDetail(
             nonUkResident = Some(NonUkResident(
-              "1990-03-23",false,None
+              Some("1990-03-23"),false,None
             ))
           )),None,None
         )),None,None,None,None,None,None,None,None,None,false,None,false,None,None,None,None,extra = RPExtra()

--- a/test/models/fe/responsiblepeople/NonUKPassportSpec.scala
+++ b/test/models/fe/responsiblepeople/NonUKPassportSpec.scala
@@ -93,7 +93,7 @@ class NonUKPassportSpec  extends PlaySpec with MockitoSugar {
             Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = true,
                   passportDetails = Some(
                     PassportDetail(ukPassport = false, PassportNum(
@@ -120,7 +120,7 @@ class NonUKPassportSpec  extends PlaySpec with MockitoSugar {
             Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = true,
                   passportDetails = Some(
                     PassportDetail(false, PassportNum(
@@ -147,7 +147,7 @@ class NonUKPassportSpec  extends PlaySpec with MockitoSugar {
             idDetails = Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = false,
                   passportDetails = None
                 ))
@@ -170,7 +170,7 @@ class NonUKPassportSpec  extends PlaySpec with MockitoSugar {
             idDetails = Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = false,
                   passportDetails = None
                 ))

--- a/test/models/fe/responsiblepeople/PersonResidenceTypeSpec.scala
+++ b/test/models/fe/responsiblepeople/PersonResidenceTypeSpec.scala
@@ -51,7 +51,7 @@ class PersonResidenceTypeSpec extends PlaySpec {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,
@@ -73,7 +73,7 @@ class PersonResidenceTypeSpec extends PlaySpec {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               false,
@@ -96,7 +96,7 @@ class PersonResidenceTypeSpec extends PlaySpec {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             None
           ))

--- a/test/models/fe/responsiblepeople/ResidenceTypeSpec.scala
+++ b/test/models/fe/responsiblepeople/ResidenceTypeSpec.scala
@@ -30,7 +30,7 @@ class ResidenceTypeSpec extends PlaySpec {
         Some(IdDetail(
           None,
           Some(NonUkResident(
-            "2001-01-01",
+            Some("2001-01-01"),
             true,
             Some(PassportDetail(
               true,

--- a/test/models/fe/responsiblepeople/UKPassportSpec.scala
+++ b/test/models/fe/responsiblepeople/UKPassportSpec.scala
@@ -71,7 +71,7 @@ class UKPassportSpec  extends PlaySpec with MockitoSugar {
           idDetails = Some(IdDetail(
             nonUkResident = Some(
               NonUkResident(
-                dateOfBirth = "",
+                dateOfBirth = Some(""),
                 passportHeld = true,
                 passportDetails = Some(
                   PassportDetail(ukPassport = true, PassportNum(Some("87654321")))
@@ -109,7 +109,7 @@ class UKPassportSpec  extends PlaySpec with MockitoSugar {
             idDetails = Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = true,
                   passportDetails = Some(
                     PassportDetail(ukPassport = true, PassportNum(Some("87654321")))
@@ -133,7 +133,7 @@ class UKPassportSpec  extends PlaySpec with MockitoSugar {
             idDetails = Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = true,
                   passportDetails = Some(
                     PassportDetail(ukPassport = true, PassportNum(None))
@@ -155,7 +155,7 @@ class UKPassportSpec  extends PlaySpec with MockitoSugar {
             idDetails = Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = false,
                   passportDetails = None
                 ))
@@ -177,7 +177,7 @@ class UKPassportSpec  extends PlaySpec with MockitoSugar {
             idDetails = Some(IdDetail(
               nonUkResident = Some(
                 NonUkResident(
-                  dateOfBirth = "",
+                  dateOfBirth = Some(""),
                   passportHeld = false,
                   passportDetails = None
                 ))


### PR DESCRIPTION
This fix will address a current live issue that has been brought to our attention via the phase 2 requirements around date of birth. 

Problem: 

Where a user submits an application with a non uk responsible person; whom does have a uk passport and has not entered a date of birth the system shall fail the API5 call given dob is currently mandatory in this scenario at present. 

This PR addresses this problem and amends the code such that the date of birth is no longer mandatory in this scenario. 

https://jira.tools.tax.service.gov.uk/browse/AMLS-4430

## Related / Dependant PRs?

N/A

## How Has This Been Tested?

Unit tests, manual testing and automation / acceptance test suite. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.