### PR TITLE
make DES NULL exception more meaningful in the logs

### DIFF
--- a/app/exceptions/HttpStatusException.scala
+++ b/app/exceptions/HttpStatusException.scala
@@ -16,6 +16,13 @@
 
 package exceptions
 
+import uk.gov.hmrc.play.config.AppName
+
 case class HttpStatusException(status: Int, body: Option[String]) extends Throwable {
+
   lazy val jsonBody: Option[HttpExceptionBody] = this.body flatMap { body => HttpExceptionBody.fromJson(body) }
+
+  override def getMessage: String = {
+    s"[${AppName.appName}][HttpStatusException][status] - API call failed with http response code: $status"
+  }
 }


### PR DESCRIPTION
Small code change to override message detail on HTTP exceptions in AMLS. 

Fix will change:

**exceptions.HttpStatusException: null**

Into:

**exceptions.HttpStatusException: [amls][HttpStatusException][status] - API call failed with http response code: 400**

And will result in a more meaningful error around DES API calls. 

## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?

Unit testing, manual testing and acceptance test run. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
