### PR TITLE
AMLS-4735 | DI Updates

### DIFF
--- a/app/config/AmlsGlobal.scala
+++ b/app/config/AmlsGlobal.scala
@@ -27,15 +27,25 @@ import uk.gov.hmrc.play.microservice.bootstrap.{DefaultMicroserviceGlobal, Error
 import scala.concurrent.Future
 
 object AmlsGlobal extends DefaultMicroserviceGlobal with RunMode {
-  override lazy  val auditConnector = MicroserviceAuditConnector
+
+  override protected def mode: Mode = Play.current.mode
+
+  override protected def runModeConfiguration: Configuration = Play.current.configuration
+
+  private lazy val controllerConfig = new ControllerConfiguration(Play.current)
+
+  override lazy val auditConnector = new MicroserviceAuditConnector(Play.current)
+
+  override lazy val loggingFilter = new MicroserviceLoggingFilter(controllerConfig)
+
+  override lazy val microserviceAuditFilter = new MicroserviceAuditFilter(Play.current, auditConnector, controllerConfig)
+
+  lazy val mac = new MicroserviceAuthConnector(Play.current, auditConnector)
 
   override def microserviceMetricsConfig(implicit app: Application): Option[Configuration] = app.configuration.getConfig("microservice.metrics")
 
-  override lazy  val loggingFilter = MicroserviceLoggingFilter
-
-  override lazy  val microserviceAuditFilter = MicroserviceAuditFilter
-
-  override def authFilter: Option[EssentialFilter]  = Some(MicroserviceAuthFilter)
+  override def authFilter: Option[EssentialFilter]  = Some(new MicroserviceAuthFilter(
+    new AuthParamsControllerConfiguration(controllerConfig), mac, controllerConfig))
 
   override def onError(request: RequestHeader, ex: Throwable): Future[Result] = {
     ex match {
@@ -49,8 +59,4 @@ object AmlsGlobal extends DefaultMicroserviceGlobal with RunMode {
         super.onError(request, ex)
     }
   }
-
-  override protected def mode: Mode = Play.current.mode
-
-  override protected def runModeConfiguration: Configuration = Play.current.configuration
 }

--- a/app/config/wiring.scala
+++ b/app/config/wiring.scala
@@ -18,10 +18,11 @@ package config
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import javax.inject.Inject
 import play.api.Mode.Mode
-import play.api.{Configuration, Play}
-import uk.gov.hmrc.http.hooks.HttpHooks
+import play.api.{Application, Configuration}
 import uk.gov.hmrc.http._
+import uk.gov.hmrc.http.hooks.HttpHooks
 import uk.gov.hmrc.play.audit.http.HttpAuditing
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.auth.controllers.AuthParamsControllerConfig
@@ -34,72 +35,81 @@ import uk.gov.hmrc.play.microservice.filters.{AuditFilter, LoggingFilter, Micros
 
 trait Hooks extends HttpHooks with HttpAuditing {
   override val hooks = Seq.empty
-  override lazy val auditConnector: AuditConnector = MicroserviceAuditConnector
 }
 
-trait WSHttp extends HttpGet with WSGet with HttpPut with WSPut with HttpPost with WSPost with HttpDelete  with WSDelete
+class WSHttp @Inject()(app: Application, auditConn: MicroserviceAuditConnector)
+  extends HttpGet with WSGet with HttpPut with WSPut with HttpPost with WSPost with HttpDelete  with WSDelete
       with Hooks with HttpPatch with WSPatch with AppName with RunMode {
 
+  override protected def configuration: Option[Config] = Some(app.configuration.underlying)
+
+  override protected def appNameConfiguration: Configuration = app.configuration
+
+  override protected def mode: Mode = app.mode
+
+  override protected def runModeConfiguration: Configuration = app.configuration
+
+  override protected def actorSystem: ActorSystem = app.actorSystem
+
+  override lazy val auditConnector: AuditConnector = auditConn
 }
 
-object WSHttp extends WSHttp {
-
-  override protected def configuration: Option[Config] = Some(Play.current.configuration.underlying)
-
-  override protected def appNameConfiguration: Configuration = Play.current.configuration
-
-  override protected def mode: Mode = Play.current.mode
-
-  override protected def runModeConfiguration: Configuration = Play.current.configuration
-
-  override protected def actorSystem: ActorSystem = Play.current.actorSystem
-}
-
-object MicroserviceAuditConnector extends AuditConnector with RunMode {
+class MicroserviceAuditConnector @Inject()(app: Application) extends AuditConnector with RunMode {
 
   override lazy val auditingConfig = LoadAuditingConfig("auditing")
 
-  override protected def mode: Mode = Play.current.mode
+  override protected def mode: Mode = app.mode
 
-  override protected def runModeConfiguration: Configuration = Play.current.configuration
+  override protected def runModeConfiguration: Configuration = app.configuration
 }
 
-object MicroserviceAuthConnector extends AuthConnector with ServicesConfig with WSHttp {
+class MicroserviceAuthConnector @Inject()(app: Application, ac: MicroserviceAuditConnector)
+  extends  WSHttp(app, ac) with AuthConnector with ServicesConfig {
 
-  override protected def configuration: Option[Config] = Some(Play.current.configuration.underlying)
+  override protected def configuration: Option[Config] = Some(app.configuration.underlying)
 
-  override protected def appNameConfiguration: Configuration = Play.current.configuration
+  override protected def appNameConfiguration: Configuration = app.configuration
 
-  override protected def mode: Mode = Play.current.mode
+  override protected def mode: Mode = app.mode
 
-  override protected def runModeConfiguration: Configuration = Play.current.configuration
+  override protected def runModeConfiguration: Configuration = app.configuration
 
   override val authBaseUrl = baseUrl("auth")
 
-  override protected def actorSystem: ActorSystem = Play.current.actorSystem
+  override protected def actorSystem: ActorSystem = app.actorSystem
 }
 
-object ControllerConfiguration extends ControllerConfig {
-  override lazy val controllerConfigs: Config = Play.current.configuration.underlying.getConfig("controllers")
+class ControllerConfiguration @Inject()(app: Application) extends ControllerConfig {
+  override lazy val controllerConfigs: Config = app.configuration.underlying.getConfig("controllers")
 }
 
-object AuthParamsControllerConfiguration extends AuthParamsControllerConfig {
-  lazy val controllerConfigs = ControllerConfiguration.controllerConfigs
+class AuthParamsControllerConfiguration @Inject()(config: ControllerConfiguration) extends AuthParamsControllerConfig {
+  lazy val controllerConfigs = config.controllerConfigs
 }
 
-object MicroserviceAuditFilter extends AuditFilter with AppName with MicroserviceFilterSupport {
-  override val auditConnector = MicroserviceAuditConnector
-  override def controllerNeedsAuditing(controllerName: String) = ControllerConfiguration.paramsForController(controllerName).needsAuditing
-
-  override protected def appNameConfiguration: Configuration = Play.current.configuration
+class  MicroserviceAuditFilter @Inject()(
+  app: Application,
+  ac: MicroserviceAuditConnector,
+  cc: ControllerConfiguration
+) extends AuditFilter
+  with AppName
+  with MicroserviceFilterSupport {
+  override val auditConnector = ac
+  override def controllerNeedsAuditing(controllerName: String) = cc.paramsForController(controllerName).needsAuditing
+  override protected def appNameConfiguration: Configuration = app.configuration
 }
 
-object MicroserviceLoggingFilter extends LoggingFilter with MicroserviceFilterSupport{
-  override def controllerNeedsLogging(controllerName: String) = ControllerConfiguration.paramsForController(controllerName).needsLogging
+class MicroserviceLoggingFilter @Inject()(config: ControllerConfiguration)  extends LoggingFilter with MicroserviceFilterSupport{
+  override def controllerNeedsLogging(controllerName: String) = config.paramsForController(controllerName).needsLogging
 }
 
-object MicroserviceAuthFilter extends AuthorisationFilter with MicroserviceFilterSupport{
-  override val authParamsConfig = AuthParamsControllerConfiguration
-  override val authConnector = MicroserviceAuthConnector
-  override def controllerNeedsAuth(controllerName: String): Boolean = ControllerConfiguration.paramsForController(controllerName).needsAuth
+class MicroserviceAuthFilter @Inject()(
+  apcc: AuthParamsControllerConfiguration,
+  mac: MicroserviceAuthConnector,
+  cc: ControllerConfiguration
+) extends AuthorisationFilter
+  with MicroserviceFilterSupport {
+  override val authParamsConfig = apcc
+  override val authConnector = mac
+  override def controllerNeedsAuth(controllerName: String): Boolean = cc.paramsForController(controllerName).needsAuth
 }

--- a/app/connectors/AmendVariationDESConnector.scala
+++ b/app/connectors/AmendVariationDESConnector.scala
@@ -21,17 +21,15 @@ import exceptions.HttpStatusException
 import javax.inject._
 import metrics.API6
 import models.des
-import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.{JsSuccess, Json, Writes}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpPut, HttpReads, HttpResponse}
+import play.api.{Application, Logger}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import utils.ApiRetryHelper
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait AmendVariationDESConnector extends DESConnector {
-
-  private[connectors] def httpPut: HttpPut
+class AmendVariationDESConnector @Inject()(app: Application) extends DESConnector(app) {
 
   def amend
   (amlsRegistrationNumber: String, data: des.AmendVariationRequest)

--- a/app/connectors/DESConnector.scala
+++ b/app/connectors/DESConnector.scala
@@ -17,8 +17,9 @@
 package connectors
 
 import config.{AmlsConfig, MicroserviceAuditConnector, WSHttp}
+import javax.inject.Inject
 import metrics.Metrics
-import play.api.Play
+import play.api.Application
 import play.mvc.Http.HeaderNames
 import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpPost, HttpPut}
@@ -26,27 +27,22 @@ import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.Audit
 import utils._
 
-trait DESConnector extends HttpResponseHelper {
+class DESConnector @Inject()(app: Application)
+  extends HttpResponseHelper {
 
-  private[connectors] def baseUrl: String
+  private[connectors] val baseUrl: String = AmlsConfig.desUrl
+  private[connectors] val token: String = s"Bearer ${AmlsConfig.desToken}"
+  private[connectors] val env: String = AmlsConfig.desEnv
+  private[connectors] val wsHttp:WSHttp = app.injector.instanceOf(classOf[WSHttp])
+  private[connectors] val httpPost: HttpPost = wsHttp
+  private[connectors] val httpPut: HttpPut = wsHttp
+  private[connectors] val httpGet: HttpGet = wsHttp
+  private[connectors] val metrics: Metrics = app.injector.instanceOf[Metrics]
+  private[connectors] val requestUrl = "anti-money-laundering/subscription"
+  private[connectors] val fullUrl: String = s"$baseUrl/$requestUrl"
+  private[connectors] val auditConnector: AuditConnector = new MicroserviceAuditConnector(app)
+  private[connectors] val audit: Audit = new Audit(AuditHelper.appName, auditConnector)
 
-  private[connectors] def env: String
-
-  private[connectors] def token: String
-
-  private[connectors] def httpPost: HttpPost
-
-  private[connectors] def httpGet: HttpGet
-
-  private[connectors] def metrics: Metrics
-
-  private[connectors] def audit: Audit
-
-  private[connectors] def auditConnector: AuditConnector
-
-  private[connectors] def fullUrl: String
-
-  val requestUrl = "anti-money-laundering/subscription"
 
   protected def desHeaderCarrier(implicit hc: HeaderCarrier) = {
 
@@ -56,26 +52,4 @@ trait DESConnector extends HttpResponseHelper {
       HeaderNames.CONTENT_TYPE -> "application/json;charset=utf-8"
     )
   }
-}
-
-
-object DESConnector extends SubscribeDESConnector
-  with SubscriptionStatusDESConnector
-  with ViewDESConnector
-  with AmendVariationDESConnector
-  with WithdrawSubscriptionConnector
-  with DeregisterSubscriptionConnector
-  with RegistrationDetailsDesConnector {
-
-  // $COVERAGE-OFF$
-  override private[connectors] lazy val baseUrl: String = AmlsConfig.desUrl
-  override private[connectors] lazy val token: String = s"Bearer ${AmlsConfig.desToken}"
-  override private[connectors] lazy val env: String = AmlsConfig.desEnv
-  override private[connectors] lazy val httpPost: HttpPost = WSHttp
-  override private[connectors] lazy val httpPut: HttpPut = WSHttp
-  override private[connectors] lazy val httpGet: HttpGet = WSHttp
-  override private[connectors] lazy val metrics: Metrics = Play.current.injector.instanceOf[Metrics]
-  override private[connectors] lazy val audit: Audit = new Audit(AuditHelper.appName, MicroserviceAuditConnector)
-  override private[connectors] lazy val fullUrl: String = s"$baseUrl/$requestUrl"
-  override private[connectors] lazy val auditConnector: AuditConnector = MicroserviceAuditConnector
 }

--- a/app/connectors/DeregisterSubscriptionConnector.scala
+++ b/app/connectors/DeregisterSubscriptionConnector.scala
@@ -17,20 +17,20 @@
 package connectors
 
 import audit.DeregisterSubscriptionEvent
-import com.google.inject.ImplementedBy
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import metrics.API10
 import models.des
 import models.des.{DeregisterSubscriptionRequest, DeregisterSubscriptionResponse}
-import play.api.Logger
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import play.api.libs.json.{JsSuccess, Json, Writes}
-
-import scala.concurrent.{ExecutionContext, Future}
+import play.api.{Application, Logger}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import utils.ApiRetryHelper
 
-trait DeregisterSubscriptionConnector extends DESConnector {
+import scala.concurrent.{ExecutionContext, Future}
+
+class DeregisterSubscriptionConnector @Inject()(app: Application) extends DESConnector(app) {
 
   def deregistration(amlsRegistrationNumber: String, data: DeregisterSubscriptionRequest) (
     implicit ec: ExecutionContext,

--- a/app/connectors/EnrolmentStoreConnector.scala
+++ b/app/connectors/EnrolmentStoreConnector.scala
@@ -33,9 +33,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class EnrolmentStoreConnector @Inject()(
-                                         val http: CorePut,
-                                         val metrics: Metrics,
-                                         config: AppConfig) extends HttpResponseHelper {
+  val http: CorePut,
+  val metrics: Metrics,
+  mac: MicroserviceAuditConnector,
+  config: AppConfig
+) extends HttpResponseHelper {
 
   def addKnownFacts(enrolmentKey: AmlsEnrolmentKey, knownFacts: KnownFacts)(implicit
                                                                             headerCarrier: HeaderCarrier,
@@ -52,7 +54,7 @@ class EnrolmentStoreConnector @Inject()(
     val prefix = "[EnrolmentStore][Enrolments]"
     val timer = metrics.timer(EnrolmentStoreKnownFacts)
 
-    val audit: Audit = new Audit(AuditHelper.appName, MicroserviceAuditConnector)
+    val audit: Audit = new Audit(AuditHelper.appName, mac)
 
     Logger.debug(s"$prefix - Request body: ${Json.toJson(knownFacts)}")
 

--- a/app/connectors/RegistrationDetailsDesConnector.scala
+++ b/app/connectors/RegistrationDetailsDesConnector.scala
@@ -17,14 +17,17 @@
 package connectors
 
 import config.AmlsConfig
+import javax.inject.Inject
 import models.des.registrationdetails.RegistrationDetails
+import play.api.Application
 import play.api.http.Status.OK
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import utils.ApiRetryHelper
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait RegistrationDetailsDesConnector extends DESConnector  {
+class RegistrationDetailsDesConnector @Inject()(app: Application) extends DESConnector(app) {
+
     def getRegistrationDetails(safeId: String)(
       implicit
       hc: HeaderCarrier,

--- a/app/connectors/SubscribeDESConnector.scala
+++ b/app/connectors/SubscribeDESConnector.scala
@@ -18,19 +18,18 @@ package connectors
 
 import audit.{SubscriptionEvent, SubscriptionFailedEvent}
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import metrics.API4
 import models.des
-import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.{JsSuccess, Json, Writes}
-
-import scala.concurrent.{ExecutionContext, Future}
-import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames, HttpPost, HttpReads, HttpResponse}
+import play.api.{Application, Logger}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import utils.ApiRetryHelper
 
-trait SubscribeDESConnector extends DESConnector {
+import scala.concurrent.{ExecutionContext, Future}
 
-  private[connectors] def httpPost: HttpPost
+class SubscribeDESConnector @Inject()(app: Application) extends DESConnector(app) {
 
   def subscribe
   (safeId: String, data: des.SubscriptionRequest)

--- a/app/connectors/SubscriptionStatusDESConnector.scala
+++ b/app/connectors/SubscriptionStatusDESConnector.scala
@@ -18,20 +18,19 @@ package connectors
 
 import audit.SubscriptionStatusEvent
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import metrics.API9
 import models.des
 import models.des.ReadStatusResponse
-import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.{JsSuccess, Json, Writes}
-
-import scala.concurrent.{ExecutionContext, Future}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpReads, HttpResponse}
+import play.api.{Application, Logger}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import utils.ApiRetryHelper
 
-trait SubscriptionStatusDESConnector extends DESConnector {
+import scala.concurrent.{ExecutionContext, Future}
 
-  private[connectors] def httpGet: HttpGet
+class SubscriptionStatusDESConnector @Inject()(app: Application) extends DESConnector(app) {
 
   def status(amlsRegistrationNumber: String)
   (
@@ -80,7 +79,5 @@ trait SubscriptionStatusDESConnector extends DESConnector {
         Logger.warn(s"$prefix - Failure: Exception", e)
         Future.failed(HttpStatusException(INTERNAL_SERVER_ERROR, Some(e.getMessage)))
     }
-
   }
-
 }

--- a/app/connectors/ViewDESConnector.scala
+++ b/app/connectors/ViewDESConnector.scala
@@ -18,18 +18,18 @@ package connectors
 
 import audit.SubscriptionViewEvent
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import metrics.API5
 import models.des.SubscriptionView
-import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.{JsError, JsSuccess}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpReads, HttpResponse}
+import play.api.{Application, Logger}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import utils.ApiRetryHelper
+
 import scala.concurrent.{ExecutionContext, Future}
 
-trait ViewDESConnector extends DESConnector {
-
-  private[connectors] def httpGet: HttpGet
+class ViewDESConnector  @Inject()(app: Application) extends DESConnector(app) {
 
     def view(amlsRegistrationNumber: String)(
       implicit ec: ExecutionContext,

--- a/app/connectors/WithdrawSubscriptionConnector.scala
+++ b/app/connectors/WithdrawSubscriptionConnector.scala
@@ -18,17 +18,19 @@ package connectors
 
 import audit.WithdrawSubscriptionEvent
 import exceptions.HttpStatusException
+import javax.inject.Inject
 import metrics.API8
 import models.des
 import models.des.{WithdrawSubscriptionRequest, WithdrawSubscriptionResponse}
-import play.api.Logger
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, OK}
 import play.api.libs.json.{JsSuccess, Json, Writes}
-import scala.concurrent.{ExecutionContext, Future}
+import play.api.{Application, Logger}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import utils.ApiRetryHelper
 
-trait WithdrawSubscriptionConnector extends DESConnector {
+import scala.concurrent.{ExecutionContext, Future}
+
+class WithdrawSubscriptionConnector  @Inject()(app: Application) extends DESConnector(app) {
 
   def withdrawal(amlsRegistrationNumber: String, data: WithdrawSubscriptionRequest)(implicit ec: ExecutionContext,
                                                                                     wr1: Writes[WithdrawSubscriptionRequest],

--- a/app/controllers/AmendVariationController.scala
+++ b/app/controllers/AmendVariationController.scala
@@ -33,10 +33,11 @@ import scala.concurrent.Future
 
 @Singleton
 class AmendVariationController @Inject()(
-                                          implicit val apiRetryHelper: ApiRetryHelper
-                                        ) extends BaseController {
+  implicit val apiRetryHelper: ApiRetryHelper,
+  avs: AmendVariationService
+) extends BaseController {
 
-  private[controllers] def service: AmendVariationService = AmendVariationService
+  private[controllers] def service: AmendVariationService = avs
 
   val amlsRegNoRegex = "^X[A-Z]ML00000[0-9]{6}$".r
 

--- a/app/controllers/RegistrationDetailsController.scala
+++ b/app/controllers/RegistrationDetailsController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import connectors.{DESConnector, RegistrationDetailsDesConnector}
+import connectors.RegistrationDetailsDesConnector
 import javax.inject.{Inject, Singleton}
 import models.fe.registrationdetails.RegistrationDetails
 import play.api.libs.json.Json
@@ -28,10 +28,11 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 @Singleton
 class RegistrationDetailsController @Inject()(
-                                               implicit val apiRetryHelper: ApiRetryHelper
-                                             ) extends BaseController {
+  connector: RegistrationDetailsDesConnector,
+  implicit val apiRetryHelper: ApiRetryHelper
+) extends BaseController {
 
-  private[controllers] val registrationDetailsConnector: RegistrationDetailsDesConnector = DESConnector
+  private[controllers] val registrationDetailsConnector: RegistrationDetailsDesConnector = connector
 
   def get(accountType: String, ref: String, safeId: String) = Action.async {
     implicit request =>

--- a/app/controllers/SubscriptionStatusController.scala
+++ b/app/controllers/SubscriptionStatusController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import connectors.{DESConnector, SubscriptionStatusDESConnector}
+import connectors.SubscriptionStatusDESConnector
 import exceptions.HttpStatusException
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
@@ -25,14 +25,14 @@ import play.api.libs.json._
 import play.api.mvc.Action
 import uk.gov.hmrc.play.microservice.controller.BaseController
 import utils.ApiRetryHelper
+
 import scala.concurrent.Future
 
 @Singleton
-class SubscriptionStatusController @Inject()(
-                                              implicit val apiRetryHelper: ApiRetryHelper
-                                            ) extends BaseController {
+class SubscriptionStatusController  @Inject()(ssConn: SubscriptionStatusDESConnector)
+  ( implicit val apiRetryHelper: ApiRetryHelper) extends BaseController {
 
-  private[controllers] def connector: SubscriptionStatusDESConnector = DESConnector
+  private[controllers] def connector: SubscriptionStatusDESConnector = ssConn
 
   val amlsRegNoRegex = "^X[A-Z]ML00000[0-9]{6}$".r
   val prefix = "[SubscriptionStatusController][get]"

--- a/app/controllers/SubscriptionViewController.scala
+++ b/app/controllers/SubscriptionViewController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import connectors.{DESConnector, ViewDESConnector}
+import connectors.ViewDESConnector
 import exceptions.HttpStatusException
 import javax.inject.{Inject, Singleton}
 import models.fe.SubscriptionView
@@ -30,11 +30,10 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 @Singleton
-class SubscriptionViewController @Inject()(
-  implicit val apiRetryHelper: ApiRetryHelper
-) extends BaseController {
+class SubscriptionViewController @Inject()(vdc: ViewDESConnector)
+  (implicit val apiRetryHelper: ApiRetryHelper) extends BaseController {
 
-  private[controllers] def connector: ViewDESConnector = DESConnector
+  private[controllers] def connector: ViewDESConnector = vdc
 
   val amlsRegNoRegex = "^X[A-Z]ML00000[0-9]{6}$".r
   val prefix = "[SubscriptionViewController][get]"

--- a/app/modules/Module.scala
+++ b/app/modules/Module.scala
@@ -17,13 +17,18 @@
 package modules
 
 import com.google.inject.{AbstractModule, Provides}
+import config.WSHttp
 import javax.inject.Singleton
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.DefaultDB
+import uk.gov.hmrc.http.{CorePost, CorePut, HttpGet}
 
 class Module extends AbstractModule {
-
-  override def configure() = { }
+  override def configure() = {
+    bind(classOf[HttpGet]).to(classOf[WSHttp])
+    bind(classOf[CorePost]).to(classOf[WSHttp])
+    bind(classOf[CorePut]).to(classOf[WSHttp])
+  }
 
   @Provides
   @Singleton

--- a/app/modules/Module.scala
+++ b/app/modules/Module.scala
@@ -16,27 +16,14 @@
 
 package modules
 
-import javax.inject.Singleton
-
 import com.google.inject.{AbstractModule, Provides}
-import config.{MicroserviceAuditConnector, WSHttp}
-import connectors._
+import javax.inject.Singleton
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.DefaultDB
-import uk.gov.hmrc.http.{CorePost, CorePut}
-import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 
 class Module extends AbstractModule {
-  override def configure() = {
-    bind(classOf[DeregisterSubscriptionConnector]).toInstance(DESConnector)
-    bind(classOf[WithdrawSubscriptionConnector]).toInstance(DESConnector)
-    bind(classOf[PayAPIConnector]).toInstance(PayAPIConnector)
-    bind(classOf[GovernmentGatewayAdminConnector]).toInstance(GovernmentGatewayAdminConnector)
-    bind(classOf[SubscribeDESConnector]).toInstance(DESConnector)
-    bind(classOf[CorePost]).toInstance(WSHttp)
-    bind(classOf[CorePut]).toInstance(WSHttp)
-    bind(classOf[AuditConnector]).toInstance(MicroserviceAuditConnector)
-  }
+
+  override def configure() = { }
 
   @Provides
   @Singleton

--- a/app/services/AmendVariationService.scala
+++ b/app/services/AmendVariationService.scala
@@ -17,39 +17,40 @@
 package services
 
 import java.io.InputStream
+
 import audit.AmendVariationValidationFailedEvent
 import com.eclipsesource.schema.{SchemaType, SchemaValidator}
 import config.{AmlsConfig, MicroserviceAuditConnector}
 import connectors._
+import javax.inject.Inject
 import models.Fees
 import models.des.{AmendVariationResponse => DesAmendVariationResponse, _}
 import models.fe.AmendVariationResponse
 import play.api.Logger
-import play.api.libs.json.{JsResult, JsValue, Json}
+import play.api.libs.json.Json
 import repositories.FeesRepository
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import utils.{ApiRetryHelper, DateOfChangeUpdateHelper, ResponsiblePeopleUpdateHelper, TradingPremisesUpdateHelper}
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-trait AmendVariationService extends ResponsiblePeopleUpdateHelper with TradingPremisesUpdateHelper with DateOfChangeUpdateHelper {
+class AmendVariationService @Inject()(
+  avc: AmendVariationDESConnector,
+  ssc: SubscriptionStatusDESConnector,
+  vc: ViewDESConnector,
+  mac: MicroserviceAuditConnector) extends ResponsiblePeopleUpdateHelper with TradingPremisesUpdateHelper with DateOfChangeUpdateHelper {
 
-  private[services] def amendVariationDesConnector: AmendVariationDESConnector
-
-  private[services] def viewStatusDesConnector: SubscriptionStatusDESConnector
-
-  private[services] def feeResponseRepository: FeesRepository
-
-  private[services] def viewDesConnector: ViewDESConnector
-
+  private[services] lazy val feeResponseRepository = FeesRepository()
+  private[services] val amendVariationDesConnector = avc
+  private[services] val viewStatusDesConnector: SubscriptionStatusDESConnector = ssc
+  private[services] val viewDesConnector: ViewDESConnector = vc
+  private[services] val auditConnector = mac
   private[services] val validator: SchemaValidator = new SchemaValidator()
 
-  private[services] def validateResult(request: AmendVariationRequest): JsResult[JsValue]
 
-  private[services] def amendVariationResponse(request: AmendVariationRequest, isRenewalWindow: Boolean, des: DesAmendVariationResponse): AmendVariationResponse
 
-  private[services] val auditConnector: AuditConnector
+
 
   def t(amendVariationResponse: DesAmendVariationResponse, amlsReferenceNumber: String)(implicit f: (DesAmendVariationResponse, String) => Fees) =
     f(amendVariationResponse, amlsReferenceNumber)
@@ -208,21 +209,13 @@ trait AmendVariationService extends ResponsiblePeopleUpdateHelper with TradingPr
       response.eabResdEstAgncy.equals(desRequest.eabResdEstAgncy))
   }
 
-}
+   private[services] def validateResult(request: AmendVariationRequest) = {
 
-object AmendVariationService extends AmendVariationService {
-  // $COVERAGE-OFF$
-  override private[services] val feeResponseRepository = FeesRepository()
-  override private[services] val amendVariationDesConnector = DESConnector
-  override private[services] val viewStatusDesConnector: SubscriptionStatusDESConnector = DESConnector
-  override private[services] val viewDesConnector: ViewDESConnector = DESConnector
-  override private[services] val auditConnector = MicroserviceAuditConnector
+     val stream: InputStream = getClass.getResourceAsStream (
+       if (AmlsConfig.phase2Changes) "/resources/api6_schema_release_3.0.0.json" else "/resources/API6_Request.json")
+     val lines = scala.io.Source.fromInputStream(stream).getLines
+     val linesString = lines.foldLeft[String]("")((x, y) => x.trim ++ y.trim)
 
-  val stream: InputStream = getClass.getResourceAsStream (if (AmlsConfig.phase2Changes) "/resources/api6_schema_release_3.0.0.json" else "/resources/API6_Request.json")
-  val lines = scala.io.Source.fromInputStream(stream).getLines
-  val linesString = lines.foldLeft[String]("")((x, y) => x.trim ++ y.trim)
-
-  override private[services] def validateResult(request: AmendVariationRequest) = {
     if(AmlsConfig.phase2Changes) {
       validator.validate(Json.fromJson[SchemaType](Json.parse(linesString.trim)).get, Json.toJson(request))
     }
@@ -231,6 +224,8 @@ object AmendVariationService extends AmendVariationService {
     }
   }
 
-  override private[services] def amendVariationResponse(request: AmendVariationRequest, isRenewalWindow: Boolean, des: DesAmendVariationResponse) =
+  private[services] def amendVariationResponse(request: AmendVariationRequest, isRenewalWindow: Boolean, des: DesAmendVariationResponse) =
     AmendVariationResponse.convert(request, isRenewalWindow, des)
+
+
 }

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -26,28 +26,31 @@ import exceptions.{DuplicateSubscriptionException, HttpExceptionBody, HttpStatus
 import javax.inject.Inject
 import models.des.SubscriptionRequest
 import models.enrolment.AmlsEnrolmentKey
-import models.fe.{SubscriptionFees, SubscriptionResponse}
+import models.fe.SubscriptionResponse
 import models.{Fees, KnownFact, KnownFactsForService}
 import play.api.Logger
 import play.api.libs.json.{JsResult, JsValue, Json}
 import play.mvc.Http.Status._
 import repositories.FeesRepository
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import utils.ApiRetryHelper
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class SubscriptionService @Inject()(
-                                     private[services] val desConnector: SubscribeDESConnector,
-                                     private[services] val ggConnector: GovernmentGatewayAdminConnector,
-                                     private[services] val enrolmentStoreConnector: EnrolmentStoreConnector,
-                                     private[services] val auditConnector: AuditConnector = MicroserviceAuditConnector,
-                                     val config: AppConfig
-                                   ) {
+  desConn: SubscribeDESConnector,
+  ggConn: GovernmentGatewayAdminConnector,
+  esc: EnrolmentStoreConnector,
+  ac: MicroserviceAuditConnector,
+  appConfig: AppConfig) {
+
+  val desConnector = desConn
+  val ggConnector = ggConn
+  val enrolmentStoreConnector = esc
+  val auditConnector = ac
+  val config = appConfig
 
   private[services] val feeResponseRepository: FeesRepository = FeesRepository()
-
   private val amlsRegistrationNumberRegex = "X[A-Z]ML00000[0-9]{6}$".r
 
   private[services] def validateResult(request: SubscriptionRequest): JsResult[JsValue] = {

--- a/release_notes/AMLS-4735.txt
+++ b/release_notes/AMLS-4735.txt
@@ -1,0 +1,1 @@
+ + [AMLS-4735] - 'Updating service with DI'

--- a/test/connectors/AmendVariationDESConnectorSpec.scala
+++ b/test/connectors/AmendVariationDESConnectorSpec.scala
@@ -27,7 +27,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.http.Status._
 import play.api.libs.json.Json
@@ -53,9 +53,10 @@ class AmendVariationDESConnectorSpec extends PlaySpec
     additionalConfiguration = Map(
       "microservice.services.exponential-backoff.max-attempts" -> maxRetries ))
   implicit val apiRetryHelper: ApiRetryHelper = new ApiRetryHelper(as = app.actorSystem)
+
   trait Fixture {
 
-    object testDESConnector extends AmendVariationDESConnector {
+    object testDESConnector extends AmendVariationDESConnector(app) {
       override private[connectors] val baseUrl: String = "baseUrl"
       override private[connectors] val token: String = "token"
       override private[connectors] val env: String = "ist0"

--- a/test/connectors/DeregisterSubscriptionConnectorSpec.scala
+++ b/test/connectors/DeregisterSubscriptionConnectorSpec.scala
@@ -23,20 +23,17 @@ import generators.AmlsReferenceNumberGenerator
 import metrics.{API10, Metrics}
 import models.des
 import models.des.{DeregisterSubscriptionRequest, DeregisterSubscriptionResponse, DeregistrationReason}
-import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, OK}
 import play.api.libs.json.Json
 import play.api.test.FakeApplication
-import uk.gov.hmrc.audit.HandlerResult
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpPost, HttpResponse}
-import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
-import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import utils.ApiRetryHelper
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -52,7 +49,7 @@ class DeregisterSubscriptionConnectorSpec extends PlaySpec
   implicit val apiRetryHelper: ApiRetryHelper = new ApiRetryHelper(as = app.actorSystem)
 
   trait Fixture {
-    object deregisterSubscriptionConnector extends DeregisterSubscriptionConnector {
+    object deregisterSubscriptionConnector extends DeregisterSubscriptionConnector(app) {
       override private[connectors] val baseUrl: String = "baseUrl"
       override private[connectors] val token: String = "token"
       override private[connectors] val env: String = "ist0"
@@ -61,7 +58,7 @@ class DeregisterSubscriptionConnectorSpec extends PlaySpec
       override private[connectors] val metrics: Metrics = mock[Metrics]
       override private[connectors] val audit = MockAudit
       override private[connectors] val fullUrl: String = s"$baseUrl/$requestUrl"
-      override private[connectors] def auditConnector = mock[AuditConnector]
+      override private[connectors] val auditConnector = mock[AuditConnector]
 
     }
     val mockTimer = mock[Timer.Context]

--- a/test/connectors/EnrolmentStoreConnectorSpec.scala
+++ b/test/connectors/EnrolmentStoreConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import com.codahale.metrics.Timer
-import config.AppConfig
+import config.{AppConfig, MicroserviceAuditConnector}
 import exceptions.HttpStatusException
 import generators.{AmlsReferenceNumberGenerator, BaseGenerator}
 import metrics.{EnrolmentStoreKnownFacts, Metrics}
@@ -26,7 +26,7 @@ import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.MustMatchers
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{CorePut, HeaderCarrier, HttpResponse}
@@ -51,11 +51,9 @@ class EnrolmentStoreConnectorSpec extends PlaySpec
     val http = mock[CorePut]
     val authConnector = mock[AuthConnector]
     val config = mock[AppConfig]
-
     val mockTimer = mock[Timer.Context]
+    val connector = new EnrolmentStoreConnector(http, metrics, mock[MicroserviceAuditConnector], config)
 
-    val connector = new EnrolmentStoreConnector(http, metrics, config)
-    
     val baseUrl = "http://localhost:7775"
     val enrolKey = AmlsEnrolmentKey(amlsRegistrationNumber)
     val url = s"$baseUrl/tax-enrolments/enrolments/${enrolKey.key}"

--- a/test/connectors/GovernmentGatewayAdminConnectorSpec.scala
+++ b/test/connectors/GovernmentGatewayAdminConnectorSpec.scala
@@ -25,7 +25,7 @@ import models.{KnownFact, KnownFactsForService}
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneServerPerSuite, PlaySpec}
 import play.api.test.Helpers._
 
@@ -40,7 +40,7 @@ class GovernmentGatewayAdminConnectorSpec extends PlaySpec
 
   trait Fixture {
 
-    object GGAdminConnector extends GovernmentGatewayAdminConnector {
+    object GGAdminConnector extends GovernmentGatewayAdminConnector(app) {
       override private[connectors] val serviceURL = "url"
       override private[connectors] val metrics = mock[Metrics]
       override private[connectors] val audit = MockAudit

--- a/test/connectors/PayAPIConnectorSpec.scala
+++ b/test/connectors/PayAPIConnectorSpec.scala
@@ -17,41 +17,41 @@
 package connectors
 
 import com.codahale.metrics.Timer
+import config.WSHttp
 import exceptions.HttpStatusException
 import generators.PayApiGenerator
+import javax.inject.Inject
 import metrics.{Metrics, PayAPI}
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneServerPerSuite, PlaySpec}
-import play.api.Mode.Mode
 import play.api.http.Status.OK
 import play.api.libs.json.Json
 import play.api.test.Helpers._
-import play.api.{Configuration, Play}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 import scala.concurrent.Future
 
-class PayAPIConnectorSpec extends PlaySpec with OneServerPerSuite with MockitoSugar with ScalaFutures with PayApiGenerator with IntegrationPatience {
+class PayAPIConnectorSpec @Inject()(wsHttp: WSHttp)
+  extends PlaySpec
+  with OneServerPerSuite
+  with MockitoSugar
+  with ScalaFutures
+  with PayApiGenerator
+  with IntegrationPatience {
 
   trait Fixture {
 
     val mockHttp = mock[HttpGet]
-
     val testPayment = payApiPaymentGen.sample.get
-
     val paymentUrl = s"url/pay-api/payment/${testPayment._id}"
 
-    object testConnector extends PayAPIConnector {
+    object testConnector extends PayAPIConnector(app) {
       override private[connectors] val httpGet: HttpGet = mockHttp
       override private[connectors] val paymentUrl = "url"
       override private[connectors] val metrics = mock[Metrics]
-
-      override protected def mode: Mode = Play.current.mode
-
-      override protected def runModeConfiguration: Configuration = Play.current.configuration
     }
 
     val testPaymentId = testPayment._id

--- a/test/connectors/PayAPIConnectorSpec.scala
+++ b/test/connectors/PayAPIConnectorSpec.scala
@@ -17,10 +17,8 @@
 package connectors
 
 import com.codahale.metrics.Timer
-import config.WSHttp
 import exceptions.HttpStatusException
 import generators.PayApiGenerator
-import javax.inject.Inject
 import metrics.{Metrics, PayAPI}
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
@@ -34,8 +32,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 
 import scala.concurrent.Future
 
-class PayAPIConnectorSpec @Inject()(wsHttp: WSHttp)
-  extends PlaySpec
+class PayAPIConnectorSpec extends PlaySpec
   with OneServerPerSuite
   with MockitoSugar
   with ScalaFutures

--- a/test/connectors/RegistrationDetailsDesConnectorSpec.scala
+++ b/test/connectors/RegistrationDetailsDesConnectorSpec.scala
@@ -23,7 +23,7 @@ import models.des.registrationdetails.{Organisation, Partnership, RegistrationDe
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, MustMatchers}
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.Json
@@ -46,16 +46,16 @@ class RegistrationDetailsDesConnectorSpec extends PlaySpec
 
   implicit val apiRetryHelper: ApiRetryHelper = new ApiRetryHelper(as = app.actorSystem)
 
-  val connector = new RegistrationDetailsDesConnector {
-    override private[connectors] def baseUrl = "baseUrl"
-    override private[connectors] def env = "ist0"
-    override private[connectors] def token = "token"
-    override private[connectors] def httpPost = mock[HttpPost]
-    override private[connectors] def httpGet = mockHttpGet
-    override private[connectors] def metrics = mock[Metrics]
-    override private[connectors] def audit = MockAudit
-    override private[connectors] def auditConnector = mock[AuditConnector]
-    override private[connectors] def fullUrl = s"$baseUrl/$requestUrl"
+  val connector = new RegistrationDetailsDesConnector(app) {
+    override private[connectors] val baseUrl = "baseUrl"
+    override private[connectors] val env = "ist0"
+    override private[connectors] val token = "token"
+    override private[connectors] val httpPost = mock[HttpPost]
+    override private[connectors] val httpGet = mockHttpGet
+    override private[connectors] val metrics = mock[Metrics]
+    override private[connectors] val audit = MockAudit
+    override private[connectors] val auditConnector = mock[AuditConnector]
+    override private[connectors] val fullUrl = s"$baseUrl/$requestUrl"
   }
 
   implicit val headerCarrier = HeaderCarrier()

--- a/test/connectors/SubscribeDESConnectorSpec.scala
+++ b/test/connectors/SubscribeDESConnectorSpec.scala
@@ -27,7 +27,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.http.Status._
 import play.api.libs.json.Json
@@ -57,7 +57,7 @@ class SubscribeDESConnectorSpec extends PlaySpec
 
   trait Fixture {
 
-    object testDESConnector extends SubscribeDESConnector {
+    object testDESConnector extends SubscribeDESConnector(app) {
       override private[connectors] val baseUrl: String = "baseUrl"
       override private[connectors] val token: String = "token"
       override private[connectors] val env: String = "ist0"

--- a/test/connectors/SubscriptionStatusDESConnectorSpec.scala
+++ b/test/connectors/SubscriptionStatusDESConnectorSpec.scala
@@ -27,7 +27,7 @@ import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.http.Status._
 import play.api.libs.json.Json
@@ -58,7 +58,7 @@ class SubscriptionStatusDESConnectorSpec
 
   trait Fixture {
 
-    object testDESConnector extends SubscriptionStatusDESConnector {
+    object testDESConnector extends SubscriptionStatusDESConnector(app) {
       override private[connectors] val baseUrl: String = "baseUrl"
       override private[connectors] val token: String = "token"
       override private[connectors] val env: String = "ist0"
@@ -67,7 +67,7 @@ class SubscriptionStatusDESConnectorSpec
       override private[connectors] val metrics: Metrics = mock[Metrics]
       override private[connectors] val audit = MockAudit
       override private[connectors] val fullUrl: String = s"$baseUrl/$requestUrl/"
-      override private[connectors] def auditConnector = mock[AuditConnector]
+      override private[connectors] val auditConnector = mock[AuditConnector]
 
     }
     implicit val hc = HeaderCarrier()

--- a/test/connectors/ViewDESConnectorSpec.scala
+++ b/test/connectors/ViewDESConnectorSpec.scala
@@ -47,7 +47,7 @@ class ViewDESConnectorSpec
 
   trait Fixture {
 
-    object testDESConnector extends ViewDESConnector {
+    object testDESConnector extends ViewDESConnector(app) {
       override private[connectors] val baseUrl: String = "baseUrl"
       override private[connectors] val token: String = "token"
       override private[connectors] val env: String = "ist0"
@@ -56,7 +56,7 @@ class ViewDESConnectorSpec
       override private[connectors] val metrics: Metrics = mock[Metrics]
       override private[connectors] val audit = MockAudit
       override private[connectors] val fullUrl: String = s"$baseUrl/$requestUrl/"
-      override private[connectors] def auditConnector = mock[AuditConnector]
+      override private[connectors] val auditConnector = mock[AuditConnector]
 
     }
 

--- a/test/connectors/WithdrawSubscriptionConnectorSpec.scala
+++ b/test/connectors/WithdrawSubscriptionConnectorSpec.scala
@@ -25,7 +25,7 @@ import models.des.{WithdrawSubscriptionRequest, WithdrawSubscriptionResponse, Wi
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, OK}
@@ -46,7 +46,7 @@ class WithdrawSubscriptionConnectorSpec extends PlaySpec
   implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
 
   trait Fixture {
-    object withdrawSubscriptionConnector extends WithdrawSubscriptionConnector {
+    object withdrawSubscriptionConnector extends WithdrawSubscriptionConnector(app) {
       override private[connectors] val baseUrl: String = "baseUrl"
       override private[connectors] val token: String = "token"
       override private[connectors] val env: String = "ist0"
@@ -55,7 +55,7 @@ class WithdrawSubscriptionConnectorSpec extends PlaySpec
       override private[connectors] val metrics: Metrics = mock[Metrics]
       override private[connectors] val audit = MockAudit
       override private[connectors] val fullUrl: String = s"$baseUrl/$requestUrl"
-      override private[connectors] def auditConnector = mock[AuditConnector]
+      override private[connectors] val auditConnector = mock[AuditConnector]
 
     }
 

--- a/test/controllers/AmendVariationControllerSpec.scala
+++ b/test/controllers/AmendVariationControllerSpec.scala
@@ -20,10 +20,10 @@ import exceptions.HttpStatusException
 import generators.AmlsReferenceNumberGenerator
 import models.des.{AmendVariationRequest, DesConstants}
 import models.fe
-import models.fe.businessdetails._
 import models.fe.bankdetails._
 import models.fe.businessactivities.BusinessActivities
 import models.fe.businesscustomer.{Address, ReviewDetails}
+import models.fe.businessdetails._
 import models.fe.businessmatching.{BusinessMatching, BusinessActivities => BMBusinessActivities, BusinessType => BT}
 import models.fe.declaration.{AddPerson, Director, RoleWithinBusiness}
 import org.joda.time.LocalDate
@@ -35,11 +35,12 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.{JsNull, JsValue, Json}
 import play.api.mvc.Result
+import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api.test.{FakeApplication, FakeRequest}
 import services.AmendVariationService
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{ApiRetryHelper, IterateeHelpers}
+
 import scala.concurrent.Future
 
 class AmendVariationControllerSpec extends PlaySpec
@@ -51,8 +52,10 @@ class AmendVariationControllerSpec extends PlaySpec
     with OneAppPerSuite {
 
   implicit val apiRetryHelper: ApiRetryHelper = mock[ApiRetryHelper]
+  implicit val avs: AmendVariationService = mock[AmendVariationService]
+
   val Controller = new AmendVariationController{
-    override val service: AmendVariationService = mock[AmendVariationService]
+
   }
 
   implicit val hc = HeaderCarrier()

--- a/test/controllers/RegistrationDetailsControllerSpec.scala
+++ b/test/controllers/RegistrationDetailsControllerSpec.scala
@@ -38,9 +38,9 @@ class RegistrationDetailsControllerSpec extends PlaySpec with MustMatchers with 
   implicit val hc = HeaderCarrier()
 
   implicit val apiRetryHelper: ApiRetryHelper = mock[ApiRetryHelper]
-  val controller = new RegistrationDetailsController{
-    override val registrationDetailsConnector = mock[RegistrationDetailsDesConnector]
-  }
+  implicit val rddc: RegistrationDetailsDesConnector = mock[RegistrationDetailsDesConnector]
+
+  val controller = new RegistrationDetailsController(rddc, apiRetryHelper){  }
 
   "The RegistrationDetailsController" must {
     "use the Des connector to retrieve registration details" in {

--- a/test/controllers/SubscriptionStatusControllerSpec.scala
+++ b/test/controllers/SubscriptionStatusControllerSpec.scala
@@ -20,16 +20,17 @@ import connectors.SubscriptionStatusDESConnector
 import exceptions.HttpStatusException
 import generators.AmlsReferenceNumberGenerator
 import models.des
-import org.joda.time.{LocalDate, LocalDateTime}
+import org.joda.time.LocalDateTime
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mock.MockitoSugar
-import org.scalatestplus.play.PlaySpec
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import utils.{ApiRetryHelper, IterateeHelpers}
+
 import scala.concurrent.Future
 
 class SubscriptionStatusControllerSpec
@@ -38,10 +39,14 @@ class SubscriptionStatusControllerSpec
     with ScalaFutures
     with IntegrationPatience
     with IterateeHelpers
-    with AmlsReferenceNumberGenerator{
+    with AmlsReferenceNumberGenerator
+    with OneAppPerSuite {
 
   implicit val apiRetryHelper: ApiRetryHelper = mock[ApiRetryHelper]
-  val Controller: SubscriptionStatusController = new SubscriptionStatusController {
+
+  val ssConn = new SubscriptionStatusDESConnector(app)
+
+  val Controller: SubscriptionStatusController = new SubscriptionStatusController(ssConn) {
     override val connector = mock[SubscriptionStatusDESConnector]
   }
 

--- a/test/controllers/SubscriptionViewControllerSpec.scala
+++ b/test/controllers/SubscriptionViewControllerSpec.scala
@@ -18,7 +18,6 @@ package controllers
 
 import connectors.ViewDESConnector
 import exceptions.HttpStatusException
-import generators.AmlsReferenceNumberGenerator
 import models.des.DesConstants
 import models.des.businessactivities.{BusinessActivityDetails, ExpectedAMLSTurnover}
 import models.des.msb.{CountriesList, MsbAllDetails}
@@ -27,12 +26,13 @@ import models.{SubscriptionViewModel, des}
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.api.test.{FakeApplication, FakeRequest}
 import utils.{ApiRetryHelper, IterateeHelpers}
+
 import scala.concurrent.Future
 
 class SubscriptionViewControllerSpec
@@ -50,9 +50,7 @@ class SubscriptionViewControllerSpec
   )
 
   implicit val apiRetryHelper: ApiRetryHelper = mock[ApiRetryHelper]
-  val Controller: SubscriptionViewController = new SubscriptionViewController{
-    override val connector: ViewDESConnector = mock[ViewDESConnector]
-  }
+  val Controller: SubscriptionViewController = new SubscriptionViewController (mock[ViewDESConnector])
 
   val agentDetails = DesConstants.testTradingPremisesAPI5.agentBusinessPremises.fold[Option[Seq[AgentDetails]]](None) {
     x =>
@@ -164,9 +162,7 @@ class SubscriptionViewControllerSpecPhase2
   )
 
   implicit val apiRetryHelper: ApiRetryHelper = mock[ApiRetryHelper]
-  val Controller: SubscriptionViewController = new SubscriptionViewController{
-    override val connector: ViewDESConnector = mock[ViewDESConnector]
-  }
+  val Controller: SubscriptionViewController = new SubscriptionViewController(mock[ViewDESConnector])
 
   val agentDetails = DesConstants.testTradingPremisesAPI5.agentBusinessPremises.fold[Option[Seq[AgentDetails]]](None) {
     x =>

--- a/test/services/SubscriptionServiceSpec.scala
+++ b/test/services/SubscriptionServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package services
 
-import config.AppConfig
+import config.{AppConfig, MicroserviceAuditConnector}
 import connectors.{EnrolmentStoreConnector, GovernmentGatewayAdminConnector, SubscribeDESConnector}
 import exceptions.{DuplicateSubscriptionException, HttpStatusException}
 import generators.AmlsReferenceNumberGenerator
@@ -30,11 +30,12 @@ import org.joda.time.DateTime
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.{JsResult, JsValue, Json}
 import play.api.test.Helpers._
 import repositories.FeesRepository
+import services.SubscriptionService
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import utils.ApiRetryHelper
@@ -48,14 +49,13 @@ trait TestFixture extends MockitoSugar with AmlsReferenceNumberGenerator {
   val duplicateSubscriptionMessage = "Business Partner already has an active AMLS Subscription with MLR Ref Number"
 
   class MockSubscriptionService extends SubscriptionService(
-    desConnector = mock[SubscribeDESConnector],
-    ggConnector = mock[GovernmentGatewayAdminConnector],
-    enrolmentStoreConnector = mock[EnrolmentStoreConnector],
-    auditConnector = mock[AuditConnector],
-    config = mock[AppConfig]
+    mock[SubscribeDESConnector],
+    mock[GovernmentGatewayAdminConnector],
+    mock[EnrolmentStoreConnector],
+    mock[MicroserviceAuditConnector],
+    mock[AppConfig]
   ) {
     override private[services] def validateResult(request: SubscriptionRequest): JsResult[JsValue] = successValidate
-
     override private[services] val feeResponseRepository: FeesRepository = mock[FeesRepository]
   }
 

--- a/test/utils/ApiRetryHelperSpec.scala
+++ b/test/utils/ApiRetryHelperSpec.scala
@@ -21,7 +21,7 @@ import java.time.temporal.ChronoUnit
 
 import exceptions.HttpStatusException
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.Application


### PR DESCRIPTION
Replaced deprecated static methods with DI, except for AmlsConfig / AppConfig due to their use in case class companion objects for Phase 2 toggle checks. These can be updated when toggles are removed / we upgrade to 2.6.

## Related / Dependant PRs?


## How Has This Been Tested?

Unit tests passing, acceptance tests passing, coverage report run.
Coverage is below the limit due to Master's coverage being below the limit, but has been bumped from 92.70% to 93.63%.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [X] Build passing.
- [X] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [X] Appropriate labels added.
- [X] RELEASE NOTES ADDED.