### PR TITLE
AMLS-5292 | Schema change quick fix

### DIFF
--- a/app/models/des/businessactivities/MlrActivitiesAppliedFor.scala
+++ b/app/models/des/businessactivities/MlrActivitiesAppliedFor.scala
@@ -19,7 +19,8 @@ package models.des.businessactivities
 import models.fe.businessmatching._
 import play.api.libs.json.Json
 
-case class MlrActivitiesAppliedFor(msb: Boolean, hvd: Boolean, asp: Boolean, tcsp: Boolean, eab: Boolean, bpsp: Boolean, tditpsp: Boolean)
+//TODO: Replace temporary AMP schema fix
+case class MlrActivitiesAppliedFor(msb: Boolean, hvd: Boolean, asp: Boolean, tcsp: Boolean, eab: Boolean, bpsp: Boolean, tditpsp: Boolean, amp: Boolean = false)
 
 object MlrActivitiesAppliedFor {
 
@@ -30,7 +31,7 @@ object MlrActivitiesAppliedFor {
   implicit def conv(bm: BusinessMatching): Option[MlrActivitiesAppliedFor] = {
 
     val activities = bm.activities.businessActivities
-     val mlrActivities = activities.foldLeft[MlrActivitiesAppliedFor](MlrActivitiesAppliedFor(false, false, false, false, false, false, false))((result, activity) =>
+     val mlrActivities = activities.foldLeft[MlrActivitiesAppliedFor](MlrActivitiesAppliedFor(false, false, false, false, false, false, false, false))((result, activity) =>
        activity match {
           case MoneyServiceBusiness => result.copy(msb = true)
           case HighValueDealing => result.copy(hvd = true)

--- a/release_notes/AMLS-5292.txt
+++ b/release_notes/AMLS-5292.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5292] - 'Schema change quick fix'

--- a/test/connectors/AmendVariationDESConnectorSpec.scala
+++ b/test/connectors/AmendVariationDESConnectorSpec.scala
@@ -310,7 +310,8 @@ class AmendVariationDESConnectorSpec extends PlaySpec
                "tcsp":true,
                "eab":true,
                "bpsp":true,
-               "tditpsp":true
+               "tditpsp":true,
+               "amp":false
             },
             "msbServicesCarriedOut":{
                "mt":true,

--- a/test/connectors/SubscribeDESConnectorSpec.scala
+++ b/test/connectors/SubscribeDESConnectorSpec.scala
@@ -276,7 +276,8 @@ class SubscribeDESConnectorSpec extends PlaySpec
       "tcsp": true,
       "eab": true,
       "bpsp": false,
-      "tditpsp": false
+      "tditpsp": false,
+      "amp": false
     },
     "aspServicesOffered": {
       "accountant": true,

--- a/test/models/des/SubscriptionRequestSpec.scala
+++ b/test/models/des/SubscriptionRequestSpec.scala
@@ -21,13 +21,12 @@ import models.des.aboutthebusiness.Address
 import models.des.aboutyou.{AboutYouRelease7, IndividualDetails, RoleForTheBusiness, RolesWithinBusiness}
 import models.des.businessactivities._
 import models.des.msb.{CurrSupplyToCust, _}
-import models.fe.businessdetails.{RegisteredOfficeUK, UKCorrespondenceAddress, _}
 import models.fe.businessactivities.ExpectedBusinessTurnover
+import models.fe.businessdetails.{RegisteredOfficeUK, UKCorrespondenceAddress, _}
 import org.joda.time.LocalDate
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json._
-import play.api.test.FakeApplication
 import utils.AckRefGenerator
 
 class SubscriptionRequestSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
@@ -245,7 +244,8 @@ class SubscriptionRequestSpec extends PlaySpec with MockitoSugar with OneAppPerS
       "tcsp": true,
       "eab": true,
       "bpsp": false,
-      "tditpsp": false
+      "tditpsp": false,
+      "amp": false
     },
     "aspServicesOffered": {
       "accountant": true,

--- a/test/models/des/SubscriptionViewSpec.scala
+++ b/test/models/des/SubscriptionViewSpec.scala
@@ -88,7 +88,8 @@ class SubscriptionViewSpec extends PlaySpec with OneAppPerSuite {
       "tcsp": false,
       "eab": true,
       "bpsp": false,
-      "tditpsp": false
+      "tditpsp": false,
+      "amp": false
     },
     "eabServicesCarriedOut": {
       "residentialEstateAgency": true,

--- a/test/models/des/businessActivities/BusinessActivitiesSpec.scala
+++ b/test/models/des/businessActivities/BusinessActivitiesSpec.scala
@@ -43,7 +43,8 @@ class BusinessActivitiesSpec extends PlaySpec {
           "tcsp" -> false,
           "eab" -> false,
           "bpsp" -> false,
-          "tditpsp" ->false
+          "tditpsp" ->false,
+          "amp" -> false
         ),
 	  "tcspServicesOffered" -> Json.obj("nomineeShareholders" -> true,
           "trusteeProvider" -> false,
@@ -108,7 +109,8 @@ class BusinessActivitiesSpec extends PlaySpec {
           "tcsp" -> true,
           "eab" -> false,
           "bpsp" -> false,
-          "tditpsp" ->true
+          "tditpsp" ->true,
+          "amp" -> false
         ),
         "hvdGoodsSold" -> Json.obj("alcohol" -> true,
           "tobacco" ->true,


### PR DESCRIPTION
Changes required by updating stubs to use the latest schemas. Functionality has not been updated, aim is to prevent QA becoming unusable once the new schemas are deployed.

Added "amp" to "businessActivities" > "mlrActivitiesAppliedFor", and removed "testResult" and "testDate" from "responsiblePersons".

Haven't updated the date validation - the change shouldn't affect current QA testing?
 
## Related / Dependant PRs?

https://github.com/hmrc/amls-stub/pull/131 (AMLS stubs changes)

## How Has This Been Tested?

Ran the spec tests and regression tests

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [x] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
