### PR TITLE
Amls 5779 - Letting Agent DES Integration

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -44,4 +44,5 @@ class ApplicationConfig @Inject()(config: Configuration, environment: Environmen
 
   lazy val enrolmentStoreUrl = s"${baseUrl("tax-enrolments")}"
   def enrolmentStoreToggle = config.get[Boolean]("microservice.services.feature-toggle.enrolment-store")
+  def phase3Release2La     = config.get[Boolean]("microservice.services.feature-toggle.phase3-release2-la")
 }

--- a/app/models/des/AmendVariationRequest.scala
+++ b/app/models/des/AmendVariationRequest.scala
@@ -257,6 +257,7 @@ object AmendVariationRequest {
                                        msbConv: (Option[fe.moneyservicebusiness.MoneyServiceBusiness], fe.businessmatching.BusinessMatching, Boolean) => Option[MoneyServiceBusiness],
                                        hvdConv: Option[fe.hvd.Hvd] => Option[Hvd],
                                        ampConv: Option[fe.amp.Amp] => Option[Amp],
+                                       lettingAgentConv: Option[fe.estateagentbusiness.EstateAgentBusiness] => Option[LettingAgents],
                                        messageType: AmlsMessageType,
                                        requestType: RequestType
   ): Outgoing =

--- a/app/models/des/AmendVariationRequest.scala
+++ b/app/models/des/AmendVariationRequest.scala
@@ -23,7 +23,7 @@ import models.des.asp.Asp
 import models.des.bankdetails.BankDetailsView
 import models.des.businessactivities.BusinessActivities
 import models.des.businessdetails.BusinessDetails
-import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy}
+import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy, LettingAgents}
 import models.des.hvd.Hvd
 import models.des.msb.MoneyServiceBusiness
 import models.des.responsiblepeople.ResponsiblePersons
@@ -31,8 +31,6 @@ import models.des.supervision.AspOrTcsp
 import models.des.tcsp.{TcspAll, TcspTrustCompFormationAgt}
 import models.des.tradingpremises.TradingPremises
 import models.fe
-import models.fe.tcsp.CompanyFormationAgent
-import play.api.libs.json._
 import utils.AckRefGenerator
 
 case class AmendVariationRequest(
@@ -57,6 +55,7 @@ case class AmendVariationRequest(
                                 eabResdEstAgncy : Option[EabResdEstAgncy],
                                 responsiblePersons: Option[Seq[ResponsiblePersons]],
                                 amp: Option[Amp],
+                                lettingAgents: Option[LettingAgents],
                                 extraFields: ExtraFields
                               ) {
   def setChangeIndicator(changeIndicators: ChangeIndicators): AmendVariationRequest = {
@@ -82,10 +81,28 @@ object AmendVariationRequest {
   final type Outgoing = AmendVariationRequest
   final type Incoming = fe.SubscriptionRequest
 
-  implicit def jsonReads: Reads[AmendVariationRequest] = {
-    import play.api.libs.functional.syntax._
-    import play.api.libs.json.Reads._
-    import play.api.libs.json._
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json.Reads._
+  import play.api.libs.json._
+
+  /******************************************************************
+    * As the object is now > 22 fields we need to address the tupple 22
+    * problem. This is done by splitting the reads/writes into two
+    * parts and merging them together.
+  * *****************************************************************/
+
+  val readsOne: Reads[Tuple12[String,
+    ChangeIndicators,
+    String,
+    BusinessDetails,
+    BusinessContactDetails,
+    Option[PreviouslyRegisteredMLRView],
+    Option[VATRegistration],
+    Option[CorporationTaxRegisteredCbUbLlp],
+    BusinessActivities,
+    TradingPremises,
+    Option[BankDetailsView],
+    Option[MoneyServiceBusiness]]] =
     (
       (__ \ "acknowledgementReference").read[String] and
         (__ \ "changeIndicators").read[ChangeIndicators] and
@@ -98,8 +115,22 @@ object AmendVariationRequest {
         (__ \ "businessActivities").read[BusinessActivities] and
         (__ \ "tradingPremises").read[TradingPremises] and
         (__ \ "bankAccountDetails").readNullable[BankDetailsView] and
-        (__ \ "msb").readNullable[MoneyServiceBusiness] and
-        (__ \ "hvd").readNullable[Hvd] and
+        (__ \ "msb").readNullable[MoneyServiceBusiness]
+      ).tupled
+
+  val readsTwo: Reads[Tuple11[Option[Hvd],
+    Option[Asp],
+    Option[AspOrTcsp],
+    Option[TcspAll],
+    Option[TcspTrustCompFormationAgt],
+    Option[EabAll],
+    Option[EabResdEstAgncy],
+    Option[Seq[ResponsiblePersons]],
+    Option[Amp],
+    Option[LettingAgents],
+    ExtraFields]] =
+    (
+      (__ \ "hvd").readNullable[Hvd] and
         (__ \ "asp").readNullable[Asp] and
         (__ \ "aspOrTcsp").readNullable[AspOrTcsp] and
         (__ \ "tcspAll").readNullable[TcspAll] and
@@ -108,63 +139,131 @@ object AmendVariationRequest {
         (__ \ "eabResdEstAgncy").readNullable[EabResdEstAgncy] and
         (__ \ "responsiblePersons").readNullable[Seq[ResponsiblePersons]] and
         (__ \ "amp").readNullable[Amp] and
+        (__ \ "lettingAgents").readNullable[LettingAgents] and
         __.read[ExtraFields]
-      ) (AmendVariationRequest.apply _)
+      ).tupled
+
+  //Combine reads
+  implicit val reads: Reads[AmendVariationRequest] = (readsOne and readsTwo) {
+    (first, second) =>
+      AmendVariationRequest(
+        first._1, first._2, first._3, first._4, first._5, first._6, first._7, first._8, first._9, first._10, first._11, first._12,
+        second._1, second._2, second._3, second._4, second._5, second._6, second._7, second._8, second._9, second._10, second._11)
   }
 
-  implicit def jsonWrites: Writes[AmendVariationRequest] = {
-    import play.api.libs.functional.syntax._
+  val writesOne: OWrites[Tuple12[String,
+    ChangeIndicators,
+    String,
+    BusinessDetails,
+    BusinessContactDetails,
+    Option[PreviouslyRegisteredMLRView],
+    Option[VATRegistration],
+    Option[CorporationTaxRegisteredCbUbLlp],
+    BusinessActivities,
+    TradingPremises,
+    Option[BankDetailsView],
+    Option[MoneyServiceBusiness]]] =
     (
       (__ \ "acknowledgementReference").write[String] and
-      (__ \ "changeIndicators").write[ChangeIndicators] and
-      (__ \ "amlsMessageType").write[String] and
-      (__ \ "businessDetails").write[BusinessDetails] and
-      (__ \ "businessContactDetails").write[BusinessContactDetails] and
-      (__ \ "businessReferencesAll").write[Option[PreviouslyRegisteredMLRView]] and
-      (__ \ "businessReferencesAllButSp").writeNullable[VATRegistration] and
-      (__ \ "businessReferencesCbUbLlp").writeNullable[CorporationTaxRegisteredCbUbLlp] and
-      (__ \ "businessActivities").write[BusinessActivities] and
-      (__ \ "tradingPremises").write[TradingPremises] and
-      (__ \ "bankAccountDetails").write[Option[BankDetailsView]] and
-      (__ \ "msb").writeNullable[MoneyServiceBusiness] and
+        (__ \ "changeIndicators").write[ChangeIndicators] and
+        (__ \ "amlsMessageType").write[String] and
+        (__ \ "businessDetails").write[BusinessDetails] and
+        (__ \ "businessContactDetails").write[BusinessContactDetails] and
+        (__ \ "businessReferencesAll").write[Option[PreviouslyRegisteredMLRView]] and
+        (__ \ "businessReferencesAllButSp").writeNullable[VATRegistration] and
+        (__ \ "businessReferencesCbUbLlp").writeNullable[CorporationTaxRegisteredCbUbLlp] and
+        (__ \ "businessActivities").write[BusinessActivities] and
+        (__ \ "tradingPremises").write[TradingPremises] and
+        (__ \ "bankAccountDetails").write[Option[BankDetailsView]] and
+        (__ \ "msb").writeNullable[MoneyServiceBusiness]
+      ) (t => t)
+
+  val writesTwo: OWrites[Tuple11[Option[Hvd],
+    Option[Asp],
+    Option[AspOrTcsp],
+    Option[TcspAll],
+    Option[TcspTrustCompFormationAgt],
+    Option[EabAll],
+    Option[EabResdEstAgncy],
+    Option[Seq[ResponsiblePersons]],
+    Option[Amp],
+    Option[LettingAgents],
+    ExtraFields]] =
+    (
       (__ \ "hvd").writeNullable[Hvd] and
-      (__ \ "asp").writeNullable[Asp] and
-      (__ \ "aspOrTcsp").writeNullable[AspOrTcsp] and
-      (__ \ "tcspAll").writeNullable[TcspAll] and
-      (__ \ "tcspTrustCompFormationAgt").writeNullable[TcspTrustCompFormationAgt] and
-      (__ \ "eabAll").writeNullable[EabAll] and
-      (__ \ "eabResdEstAgncy").writeNullable[EabResdEstAgncy] and
-      (__ \ "responsiblePersons").write[Option[Seq[ResponsiblePersons]]] and
-      (__ \ "amp").writeNullable[Amp] and
-      __.write[ExtraFields]
-      ) (unlift(AmendVariationRequest.unapply _))
+        (__ \ "asp").writeNullable[Asp] and
+        (__ \ "aspOrTcsp").writeNullable[AspOrTcsp] and
+        (__ \ "tcspAll").writeNullable[TcspAll] and
+        (__ \ "tcspTrustCompFormationAgt").writeNullable[TcspTrustCompFormationAgt] and
+        (__ \ "eabAll").writeNullable[EabAll] and
+        (__ \ "eabResdEstAgncy").writeNullable[EabResdEstAgncy] and
+        (__ \ "responsiblePersons").write[Option[Seq[ResponsiblePersons]]] and
+        (__ \ "amp").writeNullable[Amp] and
+        (__ \ "lettingAgents").writeNullable[LettingAgents] and
+        __.write[ExtraFields]
+      ) (t => t)
+
+  //Combine the writes
+  implicit val writes: Writes[AmendVariationRequest] = Writes { (amendVariationRequest:AmendVariationRequest) =>
+    val fieldsOne = (
+      amendVariationRequest.acknowledgementReference,
+      amendVariationRequest.changeIndicators,
+      amendVariationRequest.amlsMessageType,
+      amendVariationRequest.businessDetails,
+      amendVariationRequest.businessContactDetails,
+      amendVariationRequest.businessReferencesAll,
+      amendVariationRequest.businessReferencesAllButSp,
+      amendVariationRequest.businessReferencesCbUbLlp,
+      amendVariationRequest.businessActivities,
+      amendVariationRequest.tradingPremises,
+      amendVariationRequest.bankAccountDetails,
+      amendVariationRequest.msb
+    )
+
+    val fieldsTwo = (
+      amendVariationRequest.hvd,
+      amendVariationRequest.asp,
+      amendVariationRequest.aspOrTcsp,
+      amendVariationRequest.tcspAll,
+      amendVariationRequest.tcspTrustCompFormationAgt,
+      amendVariationRequest.eabAll,
+      amendVariationRequest.eabResdEstAgncy,
+      amendVariationRequest.responsiblePersons,
+      amendVariationRequest.amp,
+      amendVariationRequest.lettingAgents,
+      amendVariationRequest.extraFields
+    )
+
+    val w1: JsObject = Json.toJsObject(fieldsOne)(writesOne)
+    val w2: JsObject = Json.toJsObject(fieldsTwo)(writesTwo)
+    w1.deepMerge(w2)
   }
 
   // scalastyle:off
   implicit def convert(data: Incoming)(implicit
                                        gen: AckRefGenerator,
                                        conv: Incoming => BusinessActivities,
-                                       conv2 : fe.estateagentbusiness.EstateAgentBusiness => EabAll,
-                                       prevRegMLR : fe.businessdetails.BusinessDetails => Option[PreviouslyRegisteredMLR],
-                                       vatABConv : fe.businessdetails.BusinessDetails => Option[VATRegistration],
-                                       contactABConv : fe.businessdetails.BusinessDetails => BusinessContactDetails,
-                                       conv4 : Seq[fe.bankdetails.BankDetails] => Option[BankDetailsView],
-                                       tpConv : Seq[fe.tradingpremises.TradingPremises] => TradingPremises,
+                                       conv2: fe.estateagentbusiness.EstateAgentBusiness => EabAll,
+                                       prevRegMLR: fe.businessdetails.BusinessDetails => Option[PreviouslyRegisteredMLR],
+                                       vatABConv: fe.businessdetails.BusinessDetails => Option[VATRegistration],
+                                       contactABConv: fe.businessdetails.BusinessDetails => BusinessContactDetails,
+                                       conv4: Seq[fe.bankdetails.BankDetails] => Option[BankDetailsView],
+                                       tpConv: Seq[fe.tradingpremises.TradingPremises] => TradingPremises,
                                        aboutyouConv: fe.declaration.AddPerson => AboutYouRelease7,
-                                       aspConv : Option[fe.asp.Asp] => Option[Asp],
+                                       aspConv: Option[fe.asp.Asp] => Option[Asp],
                                        tcspAllConv: fe.tcsp.Tcsp => TcspAll,
                                        tcspTrustCompConv: fe.tcsp.Tcsp => TcspTrustCompFormationAgt,
                                        responsiblePeopleConv: (Option[Seq[fe.responsiblepeople.ResponsiblePeople]], fe.businessmatching.BusinessMatching) => Option[Seq[ResponsiblePersons]],
-                                       msbConv : (Option[fe.moneyservicebusiness.MoneyServiceBusiness], fe.businessmatching.BusinessMatching, Boolean) => Option[MoneyServiceBusiness],
-                                       hvdConv : Option[fe.hvd.Hvd] => Option[Hvd],
-                                       ampConv : Option[fe.amp.Amp] => Option[Amp],
-                                       messageType : AmlsMessageType,
+                                       msbConv: (Option[fe.moneyservicebusiness.MoneyServiceBusiness], fe.businessmatching.BusinessMatching, Boolean) => Option[MoneyServiceBusiness],
+                                       hvdConv: Option[fe.hvd.Hvd] => Option[Hvd],
+                                       ampConv: Option[fe.amp.Amp] => Option[Amp],
+                                       messageType: AmlsMessageType,
                                        requestType: RequestType
   ): Outgoing =
     AmendVariationRequest(
       acknowledgementReference = gen.ackRef,
       changeIndicators = ChangeIndicators(false),
-      amlsMessageType =  messageType,
+      amlsMessageType = messageType,
       businessDetails = data.businessMatchingSection,
       businessContactDetails = data.businessDetailsSection,
       businessReferencesAll = data.businessDetailsSection,
@@ -178,7 +277,7 @@ object AmendVariationRequest {
       asp = data.aspSection,
       aspOrTcsp = AspOrTcsp.conv(data.supervisionSection),
       tcspAll = data.tcspSection.map(tcspAllConv),
-      tcspTrustCompFormationAgt = if(data.tcspServicesOffered.isDefined && data.tcspServicesOffered.get.trustOrCompFormAgent) {
+      tcspTrustCompFormationAgt = if (data.tcspServicesOffered.isDefined && data.tcspServicesOffered.get.trustOrCompFormAgent) {
         data.tcspSection.map(tcspTrustCompConv)
       } else {
         None
@@ -187,6 +286,7 @@ object AmendVariationRequest {
       eabResdEstAgncy = data.eabSection,
       responsiblePersons = responsiblePeopleConv(data.responsiblePeopleSection, data.businessMatchingSection),
       extraFields = data.aboutYouSection,
-      amp = data.ampSection
+      amp = data.ampSection,
+      lettingAgents = data.eabSection
     )
 }

--- a/app/models/des/AmendVariationRequest.scala
+++ b/app/models/des/AmendVariationRequest.scala
@@ -58,6 +58,7 @@ case class AmendVariationRequest(
                                 lettingAgents: Option[LettingAgents],
                                 extraFields: ExtraFields
                               ) {
+
   def setChangeIndicator(changeIndicators: ChangeIndicators): AmendVariationRequest = {
     this.copy(changeIndicators = changeIndicators)
   }

--- a/app/models/des/SubscriptionRequest.scala
+++ b/app/models/des/SubscriptionRequest.scala
@@ -23,7 +23,7 @@ import models.des.asp.Asp
 import models.des.bankdetails.BankDetails
 import models.des.businessactivities.BusinessActivities
 import models.des.businessdetails.BusinessDetails
-import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy}
+import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy, LettingAgents}
 import models.des.hvd.Hvd
 import models.des.msb.MoneyServiceBusiness
 import models.des.responsiblepeople.ResponsiblePersons
@@ -55,7 +55,8 @@ case class SubscriptionRequest(
                                 amp: Option[Amp],
                                 responsiblePersons: Option[Seq[ResponsiblePersons]],
                                 filingIndividual: AboutYouRelease7,
-                                declaration: Declaration
+                                declaration: Declaration,
+                                lettingAgents: Option[LettingAgents]
                               )
 
 object SubscriptionRequest {
@@ -106,6 +107,7 @@ object SubscriptionRequest {
       amp = data.ampSection,
       responsiblePersons = responsiblePeopleConv(data.responsiblePeopleSection, data.businessMatchingSection),
       filingIndividual = data.aboutYouSection,
-      declaration = Declaration(true)
+      declaration = Declaration(true),
+      lettingAgents = data.eabSection
     )
 }

--- a/app/models/des/SubscriptionView.scala
+++ b/app/models/des/SubscriptionView.scala
@@ -21,7 +21,7 @@ import models.des.asp.Asp
 import models.des.bankdetails.BankDetailsView
 import models.des.businessactivities.BusinessActivities
 import models.des.businessdetails.BusinessDetails
-import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy}
+import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy, LettingAgents}
 import models.des.hvd.Hvd
 import models.des.amp.Amp
 import models.des.msb.MoneyServiceBusiness
@@ -50,6 +50,7 @@ case class SubscriptionView(etmpFormBundleNumber:String,
                             eabResdEstAgncy : Option[EabResdEstAgncy],
                             responsiblePersons: Option[Seq[ResponsiblePersons]],
                             amp: Option[Amp],
+                            lettingAgents: Option[LettingAgents],
                             extraFields: ExtraFields
                            )
 
@@ -79,6 +80,7 @@ object SubscriptionView {
         (__ \ "eabResdEstAgncy").readNullable[EabResdEstAgncy] and
         (__ \ "responsiblePersons").readNullable[Seq[ResponsiblePersons]] and
         (__ \ "amp").readNullable[Amp] and
+        (__ \ "lettingAgents").readNullable[LettingAgents] and
         __.read[ExtraFields]
       ) (SubscriptionView.apply _)
   }
@@ -104,6 +106,7 @@ object SubscriptionView {
         (__ \ "eabResdEstAgncy").write[Option[EabResdEstAgncy]] and
         (__ \ "responsiblePersons").write[Option[Seq[ResponsiblePersons]]] and
         (__ \ "amp").write[Option[Amp]] and
+        (__ \ "lettingAgents").write[Option[LettingAgents]] and
         __.write[ExtraFields]
       ) (unlift(SubscriptionView.unapply _))
   }

--- a/app/models/des/businessactivities/EabServices.scala
+++ b/app/models/des/businessactivities/EabServices.scala
@@ -28,13 +28,14 @@ case class EabServices(
                         assetManagementCompany : Boolean,
                         landManagementAgent : Boolean,
                         developmentCompany : Boolean,
-                        socialHousingProvider : Boolean
+                        socialHousingProvider : Boolean,
+                        lettingAgents : Option[Boolean] = None
                       )
 
 object EabServices {
   implicit val format = Json.format[EabServices]
 
-  val none = EabServices(false, false, false, false, false, false, false, false, false)
+  val none = EabServices(false, false, false, false, false, false, false, false, false, None)
 
   implicit def convert(eab : Option[models.fe.estateagentbusiness.EstateAgentBusiness]) : Option[EabServices] = {
 
@@ -61,6 +62,7 @@ object EabServices {
       case LandManagement => eabServices.copy(landManagementAgent = true)
       case Development => eabServices.copy(developmentCompany = true)
       case SocialHousing => eabServices.copy(socialHousingProvider = true)
+      case Lettings => eabServices.copy(lettingAgents = Some(true))
     })
     Some(eabServices)
 

--- a/app/models/des/businessactivities/EabServices.scala
+++ b/app/models/des/businessactivities/EabServices.scala
@@ -16,7 +16,9 @@
 
 package models.des.businessactivities
 
+import config.ApplicationConfig
 import models.fe.estateagentbusiness._
+import play.api.Play
 import play.api.libs.json.Json
 
 case class EabServices(
@@ -35,7 +37,13 @@ case class EabServices(
 object EabServices {
   implicit val format = Json.format[EabServices]
 
-  val none = EabServices(false, false, false, false, false, false, false, false, false, None)
+  def appConfig = Play.current.injector.instanceOf[ApplicationConfig]
+
+  val none = if(appConfig.phase3Release2La) {
+    EabServices(false, false, false, false, false, false, false, false, false, Some(false))
+  } else {
+    EabServices(false, false, false, false, false, false, false, false, false, None)
+  }
 
   implicit def convert(eab : Option[models.fe.estateagentbusiness.EstateAgentBusiness]) : Option[EabServices] = {
 

--- a/app/models/des/estateagentbusiness/LettingAgents.scala
+++ b/app/models/des/estateagentbusiness/LettingAgents.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.des.estateagentbusiness
+
+import models.fe.estateagentbusiness.{ClientMoneyProtectionSchemeNo, ClientMoneyProtectionSchemeYes}
+import play.api.libs.json.{Json, OFormat}
+
+case class LettingAgents (clientMoneyProtection: Option[Boolean])
+
+object LettingAgents {
+
+  implicit val format: OFormat[LettingAgents] = Json.format[LettingAgents]
+
+  implicit def conv(eabOpt: Option[models.fe.estateagentbusiness.EstateAgentBusiness]): Option[LettingAgents] = {
+
+    eabOpt match {
+      case Some(x) => x.clientMoneyProtectionScheme match {
+        case Some(ClientMoneyProtectionSchemeYes) => Some(LettingAgents(clientMoneyProtection = Some(true)))
+        case Some(ClientMoneyProtectionSchemeNo) => Some(LettingAgents(clientMoneyProtection = Some(false)))
+        case _ => None
+      }
+      case _ => None
+    }
+  }
+}

--- a/app/models/des/estateagentbusiness/LettingAgents.scala
+++ b/app/models/des/estateagentbusiness/LettingAgents.scala
@@ -28,7 +28,7 @@ object LettingAgents {
   implicit def conv(eabOpt: Option[models.fe.estateagentbusiness.EstateAgentBusiness]): Option[LettingAgents] = {
 
     eabOpt match {
-      case Some(x) => x.clientMoneyProtectionScheme match {
+      case Some(eab) => eab.clientMoneyProtectionScheme match {
         case Some(ClientMoneyProtectionSchemeYes) => Some(LettingAgents(clientMoneyProtection = Some(true)))
         case Some(ClientMoneyProtectionSchemeNo) => Some(LettingAgents(clientMoneyProtection = Some(false)))
         case _ => None

--- a/app/models/fe/amp/Amp.scala
+++ b/app/models/fe/amp/Amp.scala
@@ -29,7 +29,7 @@ object Amp  {
 
   implicit def conv(view: SubscriptionView): Option[Amp] = {
     view match {
-      case SubscriptionView(_,_,_,_,_,_, ba,_,_,_,_,_,_,_,_,_,_,_, Some(amp), _) => Some(
+      case SubscriptionView(_,_,_,_,_,_, ba,_,_,_,_,_,_,_,_,_,_,_, Some(amp), _, _) => Some(
         Amp(AmpData(
           view.businessActivities.ampServicesCarriedOut,
           ba.ampServicesCarriedOut.flatMap(s => s.other.specifyOther),

--- a/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
+++ b/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.fe.estateagentbusiness
+
+import play.api.libs.json._
+
+sealed trait ClientMoneyProtectionScheme
+
+case object ClientMoneyProtectionSchemeYes extends ClientMoneyProtectionScheme
+
+case object ClientMoneyProtectionSchemeNo extends ClientMoneyProtectionScheme
+
+object ClientMoneyProtectionScheme {
+
+  import utils.MappingUtils.Implicits._
+
+  implicit val jsonReads: Reads[ClientMoneyProtectionScheme] =
+    (__ \ "clientMoneyProtection").read[Boolean] flatMap {
+      case true  => Reads(_ => JsSuccess(ClientMoneyProtectionSchemeYes))
+      case false => Reads(_ => JsSuccess(ClientMoneyProtectionSchemeNo))
+    }
+
+  implicit val jsonWrites = Writes[ClientMoneyProtectionScheme] {
+    case ClientMoneyProtectionSchemeYes => Json.obj("clientMoneyProtection" -> true)
+    case ClientMoneyProtectionSchemeNo  => Json.obj("clientMoneyProtection" -> false)
+  }
+
+  implicit def conv(desView: models.des.SubscriptionView): Option[ClientMoneyProtectionScheme] = {
+    desView.lettingAgents match {
+      case Some(la) => la.clientMoneyProtection match {
+        case Some(true) => Some(ClientMoneyProtectionSchemeYes)
+        case Some(false) => Some(ClientMoneyProtectionSchemeNo)
+      }
+      case None if(desView.businessActivities.eabServicesCarriedOut.isDefined) => Some(ClientMoneyProtectionSchemeNo)
+      case None => None
+    }
+  }
+
+}

--- a/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
+++ b/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
@@ -30,8 +30,7 @@ case object ClientMoneyProtectionSchemeNo extends ClientMoneyProtectionScheme
 object ClientMoneyProtectionScheme extends {
 
   //TODO - Ugly however; needed for feature toggle until we complete phase 3 and remove toggle
-  lazy val appConfig = Play.current.injector.instanceOf[ApplicationConfig]
-  lazy val phase3 = appConfig.phase3Release2La
+  def appConfig = Play.current.injector.instanceOf[ApplicationConfig]
 
   import utils.MappingUtils.Implicits._
 
@@ -47,12 +46,12 @@ object ClientMoneyProtectionScheme extends {
   }
 
   implicit def conv(desView: models.des.SubscriptionView): Option[ClientMoneyProtectionScheme] = {
-    (phase3, desView.lettingAgents) match {
+    (appConfig.phase3Release2La, desView.lettingAgents) match {
       case (true, Some(la)) => la.clientMoneyProtection match {
         case Some(true) => Some(ClientMoneyProtectionSchemeYes)
         case Some(false) => Some(ClientMoneyProtectionSchemeNo)
       }
-      case (true, None) if(desView.businessActivities.eabServicesCarriedOut.isDefined) => Some(ClientMoneyProtectionSchemeNo)
+      case (true, None) => None
       case _ => None
     }
   }

--- a/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
+++ b/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
@@ -27,9 +27,8 @@ case object ClientMoneyProtectionSchemeYes extends ClientMoneyProtectionScheme
 
 case object ClientMoneyProtectionSchemeNo extends ClientMoneyProtectionScheme
 
-object ClientMoneyProtectionScheme extends {
+object ClientMoneyProtectionScheme {
 
-  //TODO - Ugly however; needed for feature toggle until we complete phase 3 and remove toggle
   def appConfig = Play.current.injector.instanceOf[ApplicationConfig]
 
   import utils.MappingUtils.Implicits._

--- a/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
+++ b/app/models/fe/estateagentbusiness/ClientMoneyProtectionScheme.scala
@@ -19,6 +19,7 @@ package models.fe.estateagentbusiness
 import play.api.libs.json._
 import com.google.inject.Inject
 import config.ApplicationConfig
+import models.des.businessactivities.EabServices
 import play.api.Play
 
 sealed trait ClientMoneyProtectionScheme
@@ -47,10 +48,13 @@ object ClientMoneyProtectionScheme {
   implicit def conv(desView: models.des.SubscriptionView): Option[ClientMoneyProtectionScheme] = {
     (appConfig.phase3Release2La, desView.lettingAgents) match {
       case (true, Some(la)) => la.clientMoneyProtection match {
-        case Some(true) => Some(ClientMoneyProtectionSchemeYes)
+        case Some(true)  => Some(ClientMoneyProtectionSchemeYes)
         case Some(false) => Some(ClientMoneyProtectionSchemeNo)
       }
-      case (true, None) => None
+      case (true, None) => desView.businessActivities.eabServicesCarriedOut match {
+        case Some(EabServices(_,_,_,_,_,_,_,_,_,Some(true))) => Some(ClientMoneyProtectionSchemeNo)
+        case _                                               => None
+      }
       case _ => None
     }
   }

--- a/app/models/fe/estateagentbusiness/EstateAgentBusiness.scala
+++ b/app/models/fe/estateagentbusiness/EstateAgentBusiness.scala
@@ -20,7 +20,8 @@ case class EstateAgentBusiness(
                                 services: Option[Services] = None,
                                 redressScheme: Option[RedressScheme] = None,
                                 professionalBody: Option[ProfessionalBody] = None,
-                                penalisedUnderEstateAgentsAct: Option[PenalisedUnderEstateAgentsAct] = None
+                                penalisedUnderEstateAgentsAct: Option[PenalisedUnderEstateAgentsAct] = None,
+                                clientMoneyProtectionScheme: Option[ClientMoneyProtectionScheme] = None
                               )
 
 object EstateAgentBusiness {
@@ -32,7 +33,8 @@ object EstateAgentBusiness {
     __.read(Reads.optionNoError[Services]) and
       __.read(Reads.optionNoError[RedressScheme]) and
       __.read(Reads.optionNoError[ProfessionalBody]) and
-      __.read(Reads.optionNoError[PenalisedUnderEstateAgentsAct])
+      __.read(Reads.optionNoError[PenalisedUnderEstateAgentsAct]) and
+      __.read(Reads.optionNoError[ClientMoneyProtectionScheme])
     ) (EstateAgentBusiness.apply _)
 
   implicit val writes: Writes[EstateAgentBusiness] =
@@ -42,7 +44,8 @@ object EstateAgentBusiness {
           Json.toJson(model.services).asOpt[JsObject],
           Json.toJson(model.redressScheme).asOpt[JsObject],
           Json.toJson(model.professionalBody).asOpt[JsObject],
-          Json.toJson(model.penalisedUnderEstateAgentsAct).asOpt[JsObject]
+          Json.toJson(model.penalisedUnderEstateAgentsAct).asOpt[JsObject],
+          Json.toJson(model.clientMoneyProtectionScheme).asOpt[JsObject]
         ).flatten.fold(Json.obj()) {
           _ ++ _
         }
@@ -51,9 +54,9 @@ object EstateAgentBusiness {
   implicit def conv(view: models.des.SubscriptionView): Option[EstateAgentBusiness] = {
     (view.eabResdEstAgncy, view.businessActivities.eabServicesCarriedOut) match {
       case (Some(eabResdEstAgncy), _) =>
-        Some(EstateAgentBusiness(view.businessActivities.eabServicesCarriedOut, view.eabResdEstAgncy, view, view))
+        Some(EstateAgentBusiness(view.businessActivities.eabServicesCarriedOut, view.eabResdEstAgncy, view, view, view))
       case (None, Some(eabServicesCarriedOut)) =>
-        Some(EstateAgentBusiness(view.businessActivities.eabServicesCarriedOut, view.eabResdEstAgncy, view, view))
+        Some(EstateAgentBusiness(view.businessActivities.eabServicesCarriedOut, view.eabResdEstAgncy, view, view, view))
       case (None, None) => None
       case _ => None
     }

--- a/app/models/fe/estateagentbusiness/Service.scala
+++ b/app/models/fe/estateagentbusiness/Service.scala
@@ -43,6 +43,8 @@ case object SocialHousing extends Service
 
 case object Residential extends Service
 
+case object Lettings extends Service
+
 object Service {
 
   implicit val jsonServiceReads: Reads[Service] =
@@ -56,6 +58,7 @@ object Service {
       case JsString("07") => JsSuccess(LandManagement)
       case JsString("08") => JsSuccess(Development)
       case JsString("09") => JsSuccess(SocialHousing)
+      case JsString("10") => JsSuccess(Lettings)
       case _ => JsError((JsPath \ "services") -> JsonValidationError("error.invalid"))
     }
 
@@ -70,6 +73,7 @@ object Service {
       case LandManagement => JsString("07")
       case Development => JsString("08")
       case SocialHousing => JsString("09")
+      case Lettings => JsString("10")
     }
 }
 
@@ -91,7 +95,8 @@ object Services {
           CommonMethods.getSpecificType[Service](eabServices.assetManagementCompany, AssetManagement),
           CommonMethods.getSpecificType[Service](eabServices.landManagementAgent, LandManagement),
           CommonMethods.getSpecificType[Service](eabServices.developmentCompany, Development),
-          CommonMethods.getSpecificType[Service](eabServices.socialHousingProvider, SocialHousing)
+          CommonMethods.getSpecificType[Service](eabServices.socialHousingProvider, SocialHousing),
+          CommonMethods.getSpecificType[Service](eabServices.lettingAgents.getOrElse(false), Lettings)
         ).flatten
 
         services match {

--- a/app/models/fe/estateagentbusiness/Service.scala
+++ b/app/models/fe/estateagentbusiness/Service.scala
@@ -59,21 +59,21 @@ object Service {
       case JsString("08") => JsSuccess(Development)
       case JsString("09") => JsSuccess(SocialHousing)
       case JsString("10") => JsSuccess(Lettings)
-      case _ => JsError((JsPath \ "services") -> JsonValidationError("error.invalid"))
+      case _              => JsError((JsPath \ "services") -> JsonValidationError("error.invalid"))
     }
 
   implicit val jsonServiceWrites =
     Writes[Service] {
-      case Residential => JsString("01")
-      case Commercial => JsString("02")
-      case Auction => JsString("03")
-      case Relocation => JsString("04")
+      case Residential      => JsString("01")
+      case Commercial       => JsString("02")
+      case Auction          => JsString("03")
+      case Relocation       => JsString("04")
       case BusinessTransfer => JsString("05")
-      case AssetManagement => JsString("06")
-      case LandManagement => JsString("07")
-      case Development => JsString("08")
-      case SocialHousing => JsString("09")
-      case Lettings => JsString("10")
+      case AssetManagement  => JsString("06")
+      case LandManagement   => JsString("07")
+      case Development      => JsString("08")
+      case SocialHousing    => JsString("09")
+      case Lettings         => JsString("10")
     }
 }
 

--- a/app/utils/ChangeIndicatorHelper.scala
+++ b/app/utils/ChangeIndicatorHelper.scala
@@ -243,15 +243,19 @@ trait ChangeIndicatorHelper {
   private def convAndcompareEab(viewResponse: SubscriptionView, desRequest: AmendVariationRequest) = {
     val feEab              = EstateAgentBusiness.conv(viewResponse)
     val desEab             = Some(models.des.estateagentbusiness.EabAll.convert(feEab.getOrElse(EstateAgentBusiness())))
-    val desEabResdEstAgncy =  models.des.estateagentbusiness.EabResdEstAgncy.convert(feEab)
+    val desEabResdEstAgncy = models.des.estateagentbusiness.EabResdEstAgncy.convert(feEab)
+    val desLettingAgents   = models.des.estateagentbusiness.LettingAgents.conv(feEab)
 
     Logger.debug(s"[AmendVariationService][compareAndUpdate] convAndcompareEab - desEab: ${desEab}")
     Logger.debug(s"[AmendVariationService][compareAndUpdate] convAndcompareEab - desRequest.eabAll: ${desRequest.eabAll}")
     Logger.debug(s"[AmendVariationService][compareAndUpdate] convAndcompareEab - desEabResdEstAgncy: ${desEabResdEstAgncy}")
     Logger.debug(s"[AmendVariationService][compareAndUpdate] convAndcompareEab - desRequest.eabResdEstAgncy: ${desRequest.eabResdEstAgncy}")
+    Logger.debug(s"[AmendVariationService][compareAndUpdate] convAndcompareEab - desLettingAgents: ${desLettingAgents}")
+    Logger.debug(s"[AmendVariationService][compareAndUpdate] convAndcompareEab - desRequest.lettingAgents: ${desRequest.lettingAgents}")
 
     !(desEab.equals(desRequest.eabAll) &&
-      desEabResdEstAgncy.equals(desRequest.eabResdEstAgncy))
+      desEabResdEstAgncy.equals(desRequest.eabResdEstAgncy) &&
+      desLettingAgents.equals(desRequest.lettingAgents))
   }
 
   private def convAndCompareAspOrTcsp(viewResponse: SubscriptionView, desRequest: AmendVariationRequest) = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -274,6 +274,7 @@ microservice {
 
     feature-toggle {
       enrolment-store = true
+      phase3-release2-la = false
     }
 
     exponential-backoff {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -274,7 +274,7 @@ microservice {
 
     feature-toggle {
       enrolment-store = true
-      phase3-release2-la = true
+      phase3-release2-la = false
     }
 
     exponential-backoff {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -274,7 +274,7 @@ microservice {
 
     feature-toggle {
       enrolment-store = true
-      phase3-release2-la = false
+      phase3-release2-la = true
     }
 
     exponential-backoff {

--- a/release_notes/AMLS-5779.txt
+++ b/release_notes/AMLS-5779.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5779] - 'Phase 3 Letting Agents DES Integration'

--- a/test/connectors/ViewDESConnectorSpec.scala
+++ b/test/connectors/ViewDESConnectorSpec.scala
@@ -140,6 +140,7 @@ class ViewDESConnectorSpec extends AmlsBaseSpec with AmlsReferenceNumberGenerato
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 }

--- a/test/controllers/SubscriptionViewControllerSpec.scala
+++ b/test/controllers/SubscriptionViewControllerSpec.scala
@@ -26,6 +26,7 @@ import models.{SubscriptionViewModel, des}
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.IntegrationPatience
+import org.scalatestplus.play.OneAppPerTest
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -131,6 +132,7 @@ class SubscriptionViewControllerSpec extends AmlsBaseSpec with IntegrationPatien
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 }

--- a/test/models/DefaultDesValues.scala
+++ b/test/models/DefaultDesValues.scala
@@ -41,6 +41,9 @@ object DefaultDesValues {
   private val deseabServiceModel = Some(des.businessactivities.EabServices(false, false,
     true, false, true, false, false, false, false))
 
+  private val deseabServiceModelLA = Some(des.businessactivities.EabServices(false, false,
+    true, false, true, false, false, false, false, Some(true)))
+
   private val activityDetails = BusinessActivityDetails(true, Some(ExpectedAMLSTurnover(Some("14999"))))
   private val franchiseDetails = Some(FranchiseDetails(true, Some(Seq("Name"))))
   private val noOfEmployees = Some("10")
@@ -67,6 +70,9 @@ object DefaultDesValues {
 
   val BusinessActivitiesSection = DesBusinessActivities(mlrActivitiesAppliedFor, msbServicesCarriedOut, hvdGoodsSold, hvdAlcoholTobacco, aspServicesOffered,
     tcspServicesOffered, servicesforRegOff, deseabServiceModel, ampServices, desallActivitiesModel)
+
+  val BusinessActivitiesSectionLA = DesBusinessActivities(mlrActivitiesAppliedFor, msbServicesCarriedOut, hvdGoodsSold, hvdAlcoholTobacco, aspServicesOffered,
+    tcspServicesOffered, servicesforRegOff, deseabServiceModelLA, ampServices, desallActivitiesModel)
 
   val EabAllDetails = Some(EabAll(true, Some("Details"), false, None))
 

--- a/test/models/DefaultFEValues.scala
+++ b/test/models/DefaultFEValues.scala
@@ -182,10 +182,23 @@ object EabSection {
     Some(ProfessionalBodyNo),
     Some(PenalisedUnderEstateAgentsActYes("Details"))))
 
+  val modelLA = Some(EstateAgentBusiness(
+    Some(Services(Set(Auction, BusinessTransfer, Lettings))),
+    Some(OmbudsmanServices),
+    Some(ProfessionalBodyNo),
+    Some(PenalisedUnderEstateAgentsActYes("Details")),
+    Some(ClientMoneyProtectionSchemeYes)))
+
   val modelForView = Some(EstateAgentBusiness(Some(Services(Set(Residential, Commercial, SocialHousing,
     BusinessTransfer, Development, AssetManagement, LandManagement, Auction, Relocation))),
     Some(ThePropertyOmbudsman), Some(ProfessionalBodyYes("PrevWarnWRegProvideDetails")),
     Some(PenalisedUnderEstateAgentsActYes("EstAgncActProhibProvideDetails"))))
+
+  val modelForViewLA = Some(EstateAgentBusiness(Some(Services(Set(Residential, Commercial, SocialHousing,
+    BusinessTransfer, Development, AssetManagement, LandManagement, Auction, Relocation, Lettings))),
+    Some(ThePropertyOmbudsman), Some(ProfessionalBodyYes("PrevWarnWRegProvideDetails")),
+    Some(PenalisedUnderEstateAgentsActYes("EstAgncActProhibProvideDetails")),
+    Some(ClientMoneyProtectionSchemeYes)))
 }
 
 object MsbSection {

--- a/test/models/des/AmendVariationRequestSpec.scala
+++ b/test/models/des/AmendVariationRequestSpec.scala
@@ -35,6 +35,12 @@ class AmendVariationRequestSpec extends PlaySpec with OneAppPerSuite {
     ))
   )
 
+  val businessActivitiesLA = DesConstants.testBusinessActivitiesLA.copy(
+    all = Some(DesConstants.testBusinessActivitiesAll.copy(
+      businessActivityDetails = BusinessActivityDetails(true, Some(ExpectedAMLSTurnover(Some("£50k-£100k"))))
+    ))
+  )
+
   val release7Msb = DesConstants.testMsb.copy(
     msbAllDetails = Some(MsbAllDetails(
       Some("£50k-£100k"),
@@ -60,6 +66,14 @@ class AmendVariationRequestSpec extends PlaySpec with OneAppPerSuite {
         implicit val requestType = RequestType.Variation
         AmendVariationRequest.convert(feSubscriptionReq) must be(
           convertedDesModelRelease7.copy(amlsMessageType = "Variation")
+        )
+      }
+
+      "convert frontend model with Letting Agent to des model with Letting Agent for variation" in {
+        implicit val mt = Variation
+        implicit val requestType = RequestType.Variation
+        AmendVariationRequest.convert(feSubscriptionReqLA) must be(
+          convertedDesModelLA.copy(amlsMessageType = "Variation")
         )
       }
     }
@@ -100,37 +114,9 @@ class AmendVariationRequestSpec extends PlaySpec with OneAppPerSuite {
     )
   }
 
+  def feSubscriptionReqLA = feSubscriptionReq.copy(eabSection = EabSection.modelForViewLA)
+
   def feSubscriptionReqNoFormationAgt = feSubscriptionReq.copy(tcspSection = ASPTCSPSection.TcspModelForViewNoCompanyFormationAgent)
-
-  def convertedDesModel = AmendVariationRequest(
-    acknowledgementReference = ackref.ackRef,
-    DesConstants.testChangeIndicators,
-    "Amendment",
-    DesConstants.testBusinessDetails,
-    DesConstants.testViewBusinessContactDetails,
-    Some(PreviouslyRegisteredMLRView(false,
-      None,
-      false,
-      None)),
-    Some(DesConstants.testbusinessReferencesAllButSp),
-    Some(DesConstants.testBusinessReferencesCbUbLlp),
-    DesConstants.testBusinessActivities,
-    DesConstants.testTradingPremisesAPI6,
-    DesConstants.testBankDetails,
-    Some(DesConstants.testMsb),
-    Some(DesConstants.testHvd),
-    Some(DesConstants.testAsp),
-    Some(DesConstants.testAspOrTcsp),
-    Some(DesConstants.testTcspAll),
-    Some(DesConstants.testTcspTrustCompFormationAgt),
-    Some(DesConstants.testEabAll),
-    Some(DesConstants.testEabResdEstAgncy),
-    Some(DesConstants.testResponsiblePersonsForRpAPI6Phase2),
-    Some(DesConstants.testAmp),
-    None,
-    DesConstants.extraFields
-  )
-
 
   def convertedDesModelRelease7 = AmendVariationRequest(
     acknowledgementReference = ackref.ackRef,
@@ -159,6 +145,11 @@ class AmendVariationRequestSpec extends PlaySpec with OneAppPerSuite {
     Some(DesConstants.testAmp),
     None,
     DesConstants.extraFields
+  )
+
+  def convertedDesModelLA = convertedDesModelRelease7.copy(
+    lettingAgents = Some(DesConstants.testLettingAgents),
+    businessActivities = businessActivitiesLA
   )
 
   val newEtmpField = Some(EtmpFields(Some("2016-09-17T09:30:47Z"), Some("2016-10-17T09:30:47Z"), Some("2016-11-17T09:30:47Z"), Some("2016-12-17T09:30:47Z")))

--- a/test/models/des/AmendVariationRequestSpec.scala
+++ b/test/models/des/AmendVariationRequestSpec.scala
@@ -127,6 +127,7 @@ class AmendVariationRequestSpec extends PlaySpec with OneAppPerSuite {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersonsForRpAPI6Phase2),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -156,6 +157,7 @@ class AmendVariationRequestSpec extends PlaySpec with OneAppPerSuite {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersonsForRelease7RpAPI6Phase2),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -188,6 +190,7 @@ class AmendVariationRequestSpec extends PlaySpec with OneAppPerSuite {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersonsForRpAPI6),
     Some(DesConstants.testAmp),
+    None,
     newExtraFields
   )
 }

--- a/test/models/des/DesConstants.scala
+++ b/test/models/des/DesConstants.scala
@@ -23,13 +23,13 @@ import models.des.asp.{Asp => AspModel}
 import models.des.bankdetails._
 import models.des.businessactivities._
 import models.des.businessdetails.{BusinessDetails, BusinessType, CorpAndBodyLlps, UnincorpBody}
-import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy}
+import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy, LettingAgents}
 import models.des.hvd.{HvdFromUnseenCustDetails, ReceiptMethods, Hvd => HvdModel}
 import models.des.msb._
 import models.des.responsiblepeople.{Address, PersonName, _}
 import models.des.supervision._
 import models.des.tcsp.{TcspAll, TcspTrustCompFormationAgt}
-import models.des.tradingpremises.{Amp => TradingPremisesAmp, Address => TradingPremisesAddress, _}
+import models.des.tradingpremises.{Address => TradingPremisesAddress, Amp => TradingPremisesAmp, _}
 import org.joda.time.LocalDate
 import utils.{AckRefGenerator, StatusConstants}
 
@@ -1397,6 +1397,8 @@ object DesConstants {
   val testAmp = Amp(TransactionsAccptOvrThrshld(true, Some("2019-09-19 16:58:06.259Z")), true, 60)
   val testAmendAmp = Amp(TransactionsAccptOvrThrshld(true, Some("2019-09-19 16:58:06.259Z")), false, 60)
 
+  val testLettingAgents = LettingAgents(Some(true))
+
   val testEabResdEstAgncy = EabResdEstAgncy(true, Some("The Property Ombudsman Limited"), None)
   val testAmendEabResdEstAgncy = EabResdEstAgncy(false, None, None)
   val responsiblePersons2 = ResponsiblePersons(
@@ -2609,6 +2611,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2632,6 +2635,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2655,6 +2659,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2678,6 +2683,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2701,6 +2707,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2724,6 +2731,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2747,6 +2755,7 @@ object DesConstants {
     None,
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2770,6 +2779,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2793,6 +2803,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersonsForRp),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2817,6 +2828,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersonsForRpPhase2),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -3065,6 +3077,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.newResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.newExtraFields
   )
 
@@ -3088,6 +3101,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.viewResponsiblePersonsAPI5),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.newExtraFields
   )
 
@@ -3111,6 +3125,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.viewResponsiblePersonsAPI5),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.newExtraFields
   )
 

--- a/test/models/des/DesConstants.scala
+++ b/test/models/des/DesConstants.scala
@@ -2858,6 +2858,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersonsForRpAPI6),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2969,6 +2970,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.amendStatusResponsiblePersonsAPI5),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -2995,6 +2997,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.amendStatusResponsiblePersonsAPI5),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 
@@ -3021,6 +3024,7 @@ object DesConstants {
     Some(DesConstants.testAmendEabResdEstAgncy),
     Some(DesConstants.testAmendResponsiblePersons),
     Some(DesConstants.testAmendAmp),
+    None,
     DesConstants.extraAmendFields
   )
 
@@ -3054,6 +3058,7 @@ object DesConstants {
     Some(DesConstants.testAmendEabResdEstAgncy),
     Some(DesConstants.testAmendResponsiblePersons),
     Some(DesConstants.testAmendAmp),
+    None,
     DesConstants.newAmendExtraFields
   )
 
@@ -3224,6 +3229,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testAmendResponsiblePersonsTest1),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.newExtraFields
   )
 
@@ -3250,6 +3256,7 @@ object DesConstants {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testAmendResponsiblePersonsTest1),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.newExtraFields
   )
 

--- a/test/models/des/DesConstants.scala
+++ b/test/models/des/DesConstants.scala
@@ -159,6 +159,9 @@ object DesConstants {
     Some(testBusinessActivitiesAll)
   )
 
+  val testBusinessActivitiesLA = testBusinessActivities.copy(eabServicesCarriedOut =
+    Some(EabServices(true, true, true, true, true, true, true, true, true, Some(true))))
+
   val testBusinessActivitiesNoAlcoholOrTobacco = testBusinessActivities.copy(hvdGoodsSold = Some(testHvdGoodsSoldNoAlcoholOrTobacco))
 
   val testAmendAmpBusinessActivities = testBusinessActivities.copy(

--- a/test/models/des/SubscriptionRequestSpec.scala
+++ b/test/models/des/SubscriptionRequestSpec.scala
@@ -102,7 +102,8 @@ class SubscriptionRequestSpec extends PlaySpec with MockitoSugar with OneAppPerS
             asp = DefaultDesValues.AspSection,
             amp = DefaultDesValues.AmpSection,
             aspOrTcsp = DefaultDesValues.AspOrTcspSection,
-            declaration = Declaration(true)
+            declaration = Declaration(true),
+            lettingAgents = None
           )
         ) \ "businessReferencesAllButSp") must be(a[JsUndefined])
 
@@ -134,7 +135,8 @@ class SubscriptionRequestSpec extends PlaySpec with MockitoSugar with OneAppPerS
             asp = DefaultDesValues.AspSection,
             amp = DefaultDesValues.AmpSection,
             aspOrTcsp = DefaultDesValues.AspOrTcspSection,
-            declaration = Declaration(true)
+            declaration = Declaration(true),
+            lettingAgents = None
           )
         ) \ "businessReferencesCbUbLlp") must be(a[JsUndefined])
       }
@@ -192,7 +194,8 @@ class SubscriptionRequestSpec extends PlaySpec with MockitoSugar with OneAppPerS
       asp = DefaultDesValues.AspSection,
       amp = DefaultDesValues.AmpSection,
       aspOrTcsp = DefaultDesValues.AspOrTcspSection,
-      declaration = Declaration(true)
+      declaration = Declaration(true),
+      lettingAgents = None
     )
 
   val feSubscriptionReq = {
@@ -713,7 +716,8 @@ class SubscriptionRequestSpec extends PlaySpec with MockitoSugar with OneAppPerS
           asp = DefaultDesValues.AspSection,
           aspOrTcsp = DefaultDesValues.AspOrTcspSection,
           amp = DefaultDesValues.AmpSection,
-          declaration = Declaration(true)
+          declaration = Declaration(true),
+          lettingAgents = None
         )
 
       val feSubscriptionReq = {

--- a/test/models/des/SubscriptionRequestSpec.scala
+++ b/test/models/des/SubscriptionRequestSpec.scala
@@ -650,108 +650,122 @@ class SubscriptionRequestSpec extends PlaySpec with MockitoSugar with OneAppPerS
 
 
   "SubscriptionRequestSpec" must {
-    "convert correctly" in {
+    val businessDetailsModel = BusinessDetails(
+      PreviouslyRegisteredYes(Some("12345678")),
+      Some(ActivityStartDate(new LocalDate(2001, 1, 1))),
+      Some(VATRegisteredYes("123456789")),
+      Some(CorporationTaxRegisteredYes("1234567890")),
+      ContactingYou("019212323222323222323222323222", "abc@hotmail.co.uk"),
+      RegisteredOfficeUK("line1", "line2",
+        Some("some street"), Some("some city"), "EE1 1EE"),
+      true,
+      Some(UKCorrespondenceAddress("kap", "Trading", "Park", "lane",
+        Some("Street"), Some("city"), "EE1 1EE"))
+    )
 
-      val businessDetailsModel = BusinessDetails(
-        PreviouslyRegisteredYes(Some("12345678")),
-        Some(ActivityStartDate(new LocalDate(2001, 1, 1))),
-        Some(VATRegisteredYes("123456789")),
-        Some(CorporationTaxRegisteredYes("1234567890")),
-        ContactingYou("019212323222323222323222323222", "abc@hotmail.co.uk"),
-        RegisteredOfficeUK("line1", "line2",
-          Some("some street"), Some("some city"), "EE1 1EE"),
+    val msbSectionRelease7 = Some(MoneyServiceBusiness(
+      Some(MsbAllDetails(Some("£15k-50k"), true, Some(CountriesList(List("GB"))), true)),
+      Some(MsbMtDetails(true, Some("123456"),
+        IpspServicesDetails(true, Some(Seq(IpspDetails("name", "123456789123456")))),
         true,
-        Some(UKCorrespondenceAddress("kap", "Trading", "Park", "lane",
-          Some("Street"), Some("city"), "EE1 1EE"))
+        Some("12345678963"), Some(CountriesList(List("GB"))), Some(CountriesList(List("LA", "LV"))), None)),
+      Some(MsbCeDetailsR7(
+        Some(true), Some(CurrencySourcesR7
+        (
+          Some(MSBBankDetails(true, Some(List("Bank names")))),
+          Some(CurrencyWholesalerDetails(true, Some(List("wholesaler names")))), true)), "12345678963", Some(CurrSupplyToCust(List("USD", "MNO", "PQR"))))), None)
+    )
+
+    val desallActivitiesModel = BusinessActivitiesAll(None,
+      Some("2001-01-01"),
+      None,
+      BusinessActivityDetails(true,
+        Some(ExpectedAMLSTurnover(Some("£0-£15k")))),
+      Some(FranchiseDetails(true, Some(Seq("Name")))),
+      Some("10"),
+      Some("5"),
+      NonUkResidentCustDetails(true, Some(Seq("GB", "AB"))),
+      AuditableRecordsDetails("Yes", Some(TransactionRecordingMethod(true, true, true, Some("value")))),
+      true,
+      true,
+      Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true)))),
+      Some(MlrAdvisor(true,
+        Some(MlrAdvisorDetails(Some(AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"), "GB", Some("AA1 1AA")))), true, None)))))
+
+    val desSubscriptionReq =
+      des.SubscriptionRequest(
+        acknowledgementReference = ackref.ackRef,
+        businessDetails = DefaultDesValues.BusinessCustomerDetails,
+        businessActivities = DefaultDesValues.BusinessActivitiesSection,
+        eabAll = DefaultDesValues.EabAllDetails,
+        eabResdEstAgncy = DefaultDesValues.EabResd,
+        businessContactDetails = DefaultDesValues.AboutTheBusinessSection,
+        businessReferencesAll = DefaultDesValues.PrevRegMLR,
+        businessReferencesAllButSp = DefaultDesValues.VatALlBuySp,
+        businessReferencesCbUbLlp = DefaultDesValues.CorpTaxRegime,
+        tradingPremises = DefaultDesValues.TradingPremisesSection,
+        bankAccountDetails = DefaultDesValues.bankDetailsSection,
+        msb = msbSectionRelease7,
+        hvd = DefaultDesValues.hvdSection,
+        filingIndividual = DefaultDesValues.filingIndividual,
+        tcspAll = DefaultDesValues.tcspAllSection,
+        tcspTrustCompFormationAgt = DefaultDesValues.tcspTrustCompFormationAgtSection,
+        responsiblePersons = DefaultDesValues.ResponsiblePersonsSectionForRelease7Phase2,
+        asp = DefaultDesValues.AspSection,
+        aspOrTcsp = DefaultDesValues.AspOrTcspSection,
+        amp = DefaultDesValues.AmpSection,
+        declaration = Declaration(true),
+        lettingAgents = None
       )
 
-      val msbSectionRelease7 = Some(MoneyServiceBusiness(
-        Some(MsbAllDetails(Some("£15k-50k"), true, Some(CountriesList(List("GB"))), true)),
-        Some(MsbMtDetails(true, Some("123456"),
-          IpspServicesDetails(true, Some(Seq(IpspDetails("name", "123456789123456")))),
-          true,
-          Some("12345678963"), Some(CountriesList(List("GB"))), Some(CountriesList(List("LA", "LV"))), None)),
-        Some(MsbCeDetailsR7(
-          Some(true), Some(CurrencySourcesR7
-          (
-            Some(MSBBankDetails(true, Some(List("Bank names")))),
-            Some(CurrencyWholesalerDetails(true, Some(List("wholesaler names")))), true)), "12345678963", Some(CurrSupplyToCust(List("USD", "MNO", "PQR"))))), None)
+    val feSubscriptionReq = {
+      import models.fe.SubscriptionRequest
+      SubscriptionRequest(
+        businessMatchingSection = BusinessMatchingSection.model,
+        eabSection = EabSection.model,
+        businessDetailsSection = businessDetailsModel,
+        tradingPremisesSection = TradingPremisesSection.model,
+        bankDetailsSection = BankDetailsSection.model,
+        aboutYouSection = AboutYouSection.model,
+        businessActivitiesSection = BusinessActivitiesSection.model,
+        responsiblePeopleSection = ResponsiblePeopleSection.modelPhase2,
+        tcspSection = ASPTCSPSection.TcspSection,
+        aspSection = ASPTCSPSection.AspSection,
+        msbSection = MsbSection.completeModel,
+        hvdSection = HvdSection.completeModel,
+        ampSection = AmpSection.completeModel,
+        supervisionSection = SupervisionSection.completeModel
       )
+    }
 
-      val desallActivitiesModel = BusinessActivitiesAll(None,
-        Some("2001-01-01"),
-        None,
-        BusinessActivityDetails(true,
-          Some(ExpectedAMLSTurnover(Some("£0-£15k")))),
-        Some(FranchiseDetails(true, Some(Seq("Name")))),
-        Some("10"),
-        Some("5"),
-        NonUkResidentCustDetails(true, Some(Seq("GB", "AB"))),
-        AuditableRecordsDetails("Yes", Some(TransactionRecordingMethod(true, true, true, Some("value")))),
-        true,
-        true,
-        Some(FormalRiskAssessmentDetails(true, Some(RiskAssessmentFormat(true)))),
-        Some(MlrAdvisor(true,
-          Some(MlrAdvisorDetails(Some(AdvisorNameAddress("Name", Some("TradingName"), Address("Line1", "Line2", Some("Line3"), Some("Line4"), "GB", Some("AA1 1AA")))), true, None)))))
+    val feRelease7SubscriptionViewModel = feSubscriptionReq.copy(businessActivitiesSection = BusinessActivitiesSection.model.copy(
+      expectedBusinessTurnover = Some(ExpectedBusinessTurnover.First)
+    )
+    )
 
-      val desSubscriptionReq =
-        des.SubscriptionRequest(
-          acknowledgementReference = ackref.ackRef,
-          businessDetails = DefaultDesValues.BusinessCustomerDetails,
-          businessActivities = DefaultDesValues.BusinessActivitiesSection,
-          eabAll = DefaultDesValues.EabAllDetails,
-          eabResdEstAgncy = DefaultDesValues.EabResd,
-          businessContactDetails = DefaultDesValues.AboutTheBusinessSection,
-          businessReferencesAll = DefaultDesValues.PrevRegMLR,
-          businessReferencesAllButSp = DefaultDesValues.VatALlBuySp,
-          businessReferencesCbUbLlp = DefaultDesValues.CorpTaxRegime,
-          tradingPremises = DefaultDesValues.TradingPremisesSection,
-          bankAccountDetails = DefaultDesValues.bankDetailsSection,
-          msb = msbSectionRelease7,
-          hvd = DefaultDesValues.hvdSection,
-          filingIndividual = DefaultDesValues.filingIndividual,
-          tcspAll = DefaultDesValues.tcspAllSection,
-          tcspTrustCompFormationAgt = DefaultDesValues.tcspTrustCompFormationAgtSection,
-          responsiblePersons = DefaultDesValues.ResponsiblePersonsSectionForRelease7Phase2,
-          asp = DefaultDesValues.AspSection,
-          aspOrTcsp = DefaultDesValues.AspOrTcspSection,
-          amp = DefaultDesValues.AmpSection,
-          declaration = Declaration(true),
-          lettingAgents = None
-        )
+    val feSubscriptionViewModelLA = feSubscriptionReq.copy(eabSection = EabSection.modelLA)
 
-      val feSubscriptionReq = {
-        import models.fe.SubscriptionRequest
-        SubscriptionRequest(
-          businessMatchingSection = BusinessMatchingSection.model,
-          eabSection = EabSection.model,
-          businessDetailsSection = businessDetailsModel,
-          tradingPremisesSection = TradingPremisesSection.model,
-          bankDetailsSection = BankDetailsSection.model,
-          aboutYouSection = AboutYouSection.model,
-          businessActivitiesSection = BusinessActivitiesSection.model,
-          responsiblePeopleSection = ResponsiblePeopleSection.modelPhase2,
-          tcspSection = ASPTCSPSection.TcspSection,
-          aspSection = ASPTCSPSection.AspSection,
-          msbSection = MsbSection.completeModel,
-          hvdSection = HvdSection.completeModel,
-          ampSection = AmpSection.completeModel,
-          supervisionSection = SupervisionSection.completeModel
-        )
-      }
+    val desRelease7SubscriptionViewModel = desSubscriptionReq.copy(businessActivities = DefaultDesValues.BusinessActivitiesSection.copy(
+      all = Some(desallActivitiesModel)
+    )
+    )
 
-      val feRelease7SubscriptionViewModel = feSubscriptionReq.copy(businessActivitiesSection = BusinessActivitiesSection.model.copy(
-        expectedBusinessTurnover = Some(ExpectedBusinessTurnover.First)
-      )
-      )
-
-      val desRelease7SubscriptionViewModel = desSubscriptionReq.copy(businessActivities = DefaultDesValues.BusinessActivitiesSection.copy(
+    val desSubscriptionReqLA = desRelease7SubscriptionViewModel.copy(
+      lettingAgents = Some(DesConstants.testLettingAgents),
+      businessActivities = DefaultDesValues.BusinessActivitiesSectionLA.copy(
         all = Some(desallActivitiesModel)
       )
-      )
+    )
 
+    "convert correctly" in {
       implicit val requestType = RequestType.Subscription
       des.SubscriptionRequest.convert(feRelease7SubscriptionViewModel) must be(desRelease7SubscriptionViewModel)
+
+    }
+
+    "convert correctly with LA" in {
+      implicit val requestType = RequestType.Subscription
+      des.SubscriptionRequest.convert(feSubscriptionViewModelLA) must be(desSubscriptionReqLA)
 
     }
   }

--- a/test/models/des/SubscriptionViewSpec.scala
+++ b/test/models/des/SubscriptionViewSpec.scala
@@ -34,8 +34,9 @@ package models.des
 
 import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.{JsSuccess, Json}
+import utils.AmlsBaseSpec
 
-class SubscriptionViewSpec extends PlaySpec with OneAppPerSuite {
+class SubscriptionViewSpec extends PlaySpec with AmlsBaseSpec {
 
   "SubscriptionView" must {
     "deserialise the subscription json" when {
@@ -496,6 +497,7 @@ class SubscriptionViewSpec extends PlaySpec with OneAppPerSuite {
     Some(DesConstants.testEabResdEstAgncy),
     Some(DesConstants.testResponsiblePersons),
     Some(DesConstants.testAmp),
+    None,
     DesConstants.extraFields
   )
 

--- a/test/models/des/SubscriptionViewSpec.scala
+++ b/test/models/des/SubscriptionViewSpec.scala
@@ -52,13 +52,27 @@ class SubscriptionViewSpec extends PlaySpec with AmlsBaseSpec {
 
         Json.toJson(GetSuccessModel) must be(json)
       }
+
+      "given valid json with LA" in {
+        val json = Json.toJson(getSuccessModelLA)
+        val subscriptionViewModel = getSuccessModelLA
+
+        json.as[SubscriptionView] must be(subscriptionViewModel)
+
+        SubscriptionView.jsonReads.reads(
+          SubscriptionView.jsonWrites.writes(getSuccessModelLA)) must
+          be(JsSuccess(getSuccessModelLA))
+
+        Json.toJson(getSuccessModelLA) must be(json)
+      }
     }
   }
 
   "SubscriptionView" must {
     "deserialise real json" when {
       "given valid json" in {
-        val json = Json.parse("""{
+        val json = Json.parse(
+          """{
   "etmpFormBundleNumber": "082000001158",
   "businessDetails": {
     "typeOfLegalEntity": "Sole Proprietor"
@@ -469,9 +483,428 @@ class SubscriptionViewSpec extends PlaySpec with AmlsBaseSpec {
     "dateOfSubmission": "2016-10-24"
   }
 }""")
-        val subscriptionViewModel = GetSuccessModel
-
         json.as[SubscriptionView] mustBe a[SubscriptionView]
+
+      }
+
+      "given valid json with LA" in {
+        val jsonLA = Json.parse(
+          """{
+  "etmpFormBundleNumber": "082000001158",
+  "businessDetails": {
+    "typeOfLegalEntity": "Sole Proprietor"
+  },
+  "businessContactDetails": {
+    "businessAddress": {
+      "addressLine1": "Matheson House 1",
+      "addressLine2": "Grange Central",
+      "addressLine3": "Telford",
+      "addressLine4": "Shropshire",
+      "country": "GB",
+      "postcode": "TF3 4ER"
+    },
+    "altCorrespondenceAddress": false,
+    "businessTelNo": "0897686856765",
+    "businessEmail": "test1@test.com"
+  },
+  "businessReferencesAll": {
+    "amlsRegistered": true,
+    "mlrRegNumber": "12345678",
+    "prevRegForMlr": false
+  },
+  "businessActivities": {
+    "mlrActivitiesAppliedFor": {
+      "msb": false,
+      "hvd": false,
+      "asp": false,
+      "tcsp": false,
+      "eab": true,
+      "bpsp": false,
+      "tditpsp": false,
+      "amp": false
+    },
+    "eabServicesCarriedOut": {
+      "residentialEstateAgency": true,
+      "commercialEstateAgency": false,
+      "auctioneer": false,
+      "relocationAgent": true,
+      "businessTransferAgent": false,
+      "assetManagementCompany": false,
+      "landManagementAgent": false,
+      "developmentCompany": false,
+      "socialHousingProvider": false,
+      "lettingAgents": true
+    },
+    "all": {
+      "DateChangeFlag" : false,
+      "businessActivityDetails": {
+        "actvtsBusRegForOnlyActvtsCarOut": false,
+        "respActvtsBusRegForOnlyActvtsCarOut": {
+          "otherBusActivitiesCarriedOut": {
+            "otherBusinessActivities": "test1",
+            "anticipatedTotBusinessTurnover": "249999",
+            "mlrActivityTurnover": "249999"
+          }
+        }
+      },
+      "franchiseDetails": {
+        "isBusinessAFranchise": true,
+        "franchiserName": [
+          "test franch"
+        ]
+      },
+      "noOfEmployees": "123",
+      "noOfEmployeesForMlr": "12",
+      "nonUkResidentCustDetails": {
+        "nonUkResidentCustomers": true,
+        "whichCountries": [
+          "AR"
+        ]
+      },
+      "auditableRecordsDetails": {
+        "detailedRecordsKept": "Yes",
+        "transactionRecordingMethod": {
+          "manual": true,
+          "spreadsheet": true,
+          "commercialPackage": true,
+          "commercialPackageName": "test soft"
+        }
+      },
+      "suspiciousActivityGuidance": true,
+      "nationalCrimeAgencyRegistered": true,
+      "formalRiskAssessmentDetails": {
+        "formalRiskAssessment": true,
+        "riskAssessmentFormat": {
+          "electronicFormat": true,
+          "manualFormat": true
+        }
+      },
+      "mlrAdvisor": {
+        "doYouHaveMlrAdvisor": true,
+        "mlrAdvisorDetails": {
+          "advisorNameAddress": {
+            "name": "thing",
+            "address": {
+              "addressLine1": "add1",
+              "addressLine2": "add1",
+              "country": "GB",
+              "postcode": "post1"
+            }
+          },
+          "agentDealsWithHmrc": true
+        }
+      }
+    }
+  },
+  "tradingPremises": {
+    "ownBusinessPremises": {
+      "ownBusinessPremises": true,
+      "ownBusinessPremisesDetails": [
+        {
+          "lineId": 1,
+          "tradingName": "trade1",
+          "businessAddress": {
+            "addressLine1": "add1",
+            "addressLine2": "add1",
+            "country": "GB",
+            "postcode": "post1"
+          },
+          "residential": false,
+          "eab": {
+            "eab": true
+          },
+          "startDate": "1980-02-01",
+          "endDate": "9999-12-31"
+        },
+        {
+          "lineId": 2,
+          "tradingName": "trade2",
+          "businessAddress": {
+            "addressLine1": "add2",
+            "addressLine2": "add2",
+            "country": "GB",
+            "postcode": "post2"
+          },
+          "residential": false,
+          "eab": {
+            "eab": true
+          },
+          "startDate": "1981-02-01",
+          "endDate": "9999-12-31"
+        },
+        {
+          "lineId": 3,
+          "tradingName": "trade3",
+          "businessAddress": {
+            "addressLine1": "add3",
+            "addressLine2": "add3",
+            "country": "GB",
+            "postcode": "post3"
+          },
+          "residential": false,
+          "eab": {
+            "eab": true
+          },
+          "startDate": "1983-02-01",
+          "endDate": "9999-12-31"
+        }
+      ]
+    }
+  },
+  "bankAccountDetails": {
+    "noOfMlrBankAccounts": "",
+    "bankAccounts": [
+      {
+        "accountName": "bank1",
+        "accountType": "This business's",
+        "doYouHaveUkBankAccount": true,
+        "bankAccountDetails": {
+          "ukAccount": {
+            "sortCode": "204266",
+            "accountNumber": "12345678"
+          }
+        }
+      }
+    ]
+  },
+  "eabAll": {
+    "estateAgencyActProhibition": true,
+    "estAgncActProhibProvideDetails": "test1",
+    "prevWarnedWRegToEstateAgencyActivities": true,
+    "prevWarnWRegProvideDetails": "test1"
+  },
+  "eabResdEstAgncy": {
+    "regWithRedressScheme": true,
+    "whichRedressScheme": "The Property Ombudsman Limited"
+  },
+  "lettingAgents": {
+    "clientMoneyProtection": true
+  },
+  "responsiblePersons": [
+    {
+      "lineId": 1,
+      "nameDetails": {
+        "personName": {
+          "firstName": "fname1",
+          "lastName": "lname1"
+        },
+        "othrNamesOrAliasesDetails": {
+          "otherNamesOrAliases": true,
+          "aliases": [
+            "test"
+          ]
+        },
+        "previousNameDetails": {
+          "nameEverChanged": true,
+          "previousName": {
+            "firstName": "fn",
+            "lastName": "ln"
+          },
+          "dateOfChange": "2000-04-03"
+        }
+      },
+      "nationalityDetails": {
+        "areYouUkResident": true,
+        "idDetails": {
+          "ukResident": {
+            "nino": "AB123456C"
+          }
+        },
+        "countryOfBirth": "AG",
+        "nationality": "IE"
+      },
+      "contactCommDetails": {
+        "contactEmailAddress": "test1@test.com",
+        "primaryTeleNo": "092427342735"
+      },
+      "currentAddressDetails": {
+        "address": {
+          "addressLine1": "add1",
+          "addressLine2": "add1",
+          "country": "GB",
+          "postcode": "post1"
+        }
+      },
+      "timeAtCurrentAddress": "7-12 months",
+      "addressUnderThreeYears": {
+        "address": {
+          "addressLine1": "add2",
+          "addressLine2": "add2",
+          "country": "GB",
+          "postcode": "post2"
+        }
+      },
+      "timeAtAddressUnderThreeYears": "7-12 months",
+      "addressUnderOneYear": {
+        "address": {
+          "addressLine1": "add3",
+          "addressLine2": "add3",
+          "country": "GB",
+          "postcode": "post3"
+        }
+      },
+      "timeAtAddressUnderOneYear": "7-12 months",
+      "positionInBusiness": {
+        "soleProprietor": {
+          "soleProprietor": false,
+          "nominatedOfficer": true
+        }
+      },
+      "previousExperience": true,
+      "descOfPrevExperience": "test1",
+      "amlAndCounterTerrFinTraining": true,
+      "trainingDetails": "test1",
+      "startDate": "2000-02-01",
+      "endDate": "9999-12-31"
+    },
+    {
+      "lineId": 2,
+      "nameDetails": {
+        "personName": {
+          "firstName": "fn2",
+          "lastName": "ln2"
+        }
+      },
+      "nationalityDetails": {
+        "areYouUkResident": true,
+        "idDetails": {
+          "ukResident": {
+            "nino": "AB123456C"
+          }
+        },
+        "countryOfBirth": "AI",
+        "nationality": "GB"
+      },
+      "contactCommDetails": {
+        "contactEmailAddress": "test1@test.com",
+        "primaryTeleNo": "0829478247"
+      },
+      "currentAddressDetails": {
+        "address": {
+          "addressLine1": "add2",
+          "addressLine2": "add2",
+          "country": "GB",
+          "postcode": "post2"
+        }
+      },
+      "timeAtCurrentAddress": "1-3 years",
+      "positionInBusiness": {
+        "soleProprietor": {
+          "soleProprietor": true,
+          "nominatedOfficer": false
+        }
+      },
+      "regDetails": {
+        "vatRegistered": true,
+        "vrnNumber": "123456789",
+        "saRegistered": true,
+        "saUtr": "1234567890"
+      },
+      "previousExperience": true,
+      "descOfPrevExperience": "test1",
+      "amlAndCounterTerrFinTraining": true,
+      "trainingDetails": "test1",
+      "startDate": "2000-02-01",
+      "endDate": "9999-12-31"
+    },
+    {
+      "lineId": 3,
+      "nameDetails": {
+        "personName": {
+          "firstName": "fn3",
+          "lastName": "ln3"
+        }
+      },
+      "nationalityDetails": {
+        "areYouUkResident": true,
+        "idDetails": {
+          "ukResident": {
+            "nino": "AB123456C"
+          }
+        },
+        "countryOfBirth": "BD",
+        "nationality": "AO"
+      },
+      "contactCommDetails": {
+        "contactEmailAddress": "test1@test.com",
+        "primaryTeleNo": "4575685688"
+      },
+      "currentAddressDetails": {
+        "address": {
+          "addressLine1": "add1",
+          "addressLine2": "add1",
+          "country": "GB",
+          "postcode": "post1"
+        }
+      },
+      "timeAtCurrentAddress": "0-6 months",
+      "addressUnderThreeYears": {
+        "address": {
+          "addressLine1": "add2",
+          "addressLine2": "add2",
+          "country": "GB",
+          "postcode": "post2"
+        }
+      },
+      "timeAtAddressUnderThreeYears": "7-12 months",
+      "addressUnderOneYear": {
+        "address": {
+          "addressLine1": "add3",
+          "addressLine2": "add3",
+          "country": "GB",
+          "postcode": "post3"
+        }
+      },
+      "timeAtAddressUnderOneYear": "7-12 months",
+      "positionInBusiness": {
+        "soleProprietor": {
+          "soleProprietor": true,
+          "nominatedOfficer": true
+        }
+      },
+      "regDetails": {
+        "vatRegistered": true,
+        "vrnNumber": "123456789",
+        "saRegistered": true,
+        "saUtr": "1234567890"
+      },
+      "previousExperience": true,
+      "descOfPrevExperience": "test1",
+      "amlAndCounterTerrFinTraining": true,
+      "trainingDetails": "test1",
+      "startDate": "2000-02-01",
+      "endDate": "9999-12-31"
+    }
+  ],
+  "declaration": {
+    "declarationFlag": true
+  },
+   "filingIndividual": {
+    "individualDetails": {
+      "firstName": "fname",
+      "lastName": "lname"
+    },
+    "employedWithinBusiness": false,
+    "roleWithinBusiness":{
+      "beneficialShareholder": false,
+      "director": false,
+      "partner": false,
+      "internalAccountant": false,
+      "soleProprietor": false,
+      "nominatedOfficer": false,
+      "designatedMember": false,
+      "other": false
+    },
+    "roleForTheBusiness":{
+      "externalAccountant": true,
+      "other": false
+    }
+  },
+  "etmpFields": {
+    "dateOfSubmission": "2016-10-24"
+  }
+}""")
+        jsonLA.as[SubscriptionView] mustBe a[SubscriptionView]
 
       }
     }
@@ -499,6 +932,11 @@ class SubscriptionViewSpec extends PlaySpec with AmlsBaseSpec {
     Some(DesConstants.testAmp),
     None,
     DesConstants.extraFields
+  )
+
+  val getSuccessModelLA = GetSuccessModel.copy(lettingAgents = Some(
+    DesConstants.testLettingAgents),
+    businessActivities = DesConstants.testBusinessActivitiesLA
   )
 
 }

--- a/test/models/des/businessActivities/BusinessActivitiesSpec.scala
+++ b/test/models/des/businessActivities/BusinessActivitiesSpec.scala
@@ -69,7 +69,8 @@ class BusinessActivitiesSpec extends PlaySpec {
           "assetManagementCompany" ->false,
           "landManagementAgent" ->false,
           "developmentCompany" ->false,
-          "socialHousingProvider" ->false),
+          "socialHousingProvider" ->false,
+          "lettings"->false),
         "ampServicesCarriedOut" -> Json.obj(
           "artGallery" -> true,
           "auctionHouse" -> true,
@@ -169,7 +170,8 @@ class BusinessActivitiesSpec extends PlaySpec {
               "assetManagementCompany" -> false,
               "landManagementAgent" -> false,
               "developmentCompany" -> false,
-              "socialHousingProvider" -> false),
+              "socialHousingProvider" -> false,
+              "lettings"-> false),
         "ampServicesCarriedOut" -> Json.obj(
           "artGallery" -> true,
           "auctionHouse" -> true,

--- a/test/models/des/businessActivities/BusinessActivitiesSpec.scala
+++ b/test/models/des/businessActivities/BusinessActivitiesSpec.scala
@@ -69,8 +69,7 @@ class BusinessActivitiesSpec extends PlaySpec {
           "assetManagementCompany" ->false,
           "landManagementAgent" ->false,
           "developmentCompany" ->false,
-          "socialHousingProvider" ->false,
-          "lettings"->false),
+          "socialHousingProvider" ->false),
         "ampServicesCarriedOut" -> Json.obj(
           "artGallery" -> true,
           "auctionHouse" -> true,
@@ -170,8 +169,7 @@ class BusinessActivitiesSpec extends PlaySpec {
               "assetManagementCompany" -> false,
               "landManagementAgent" -> false,
               "developmentCompany" -> false,
-              "socialHousingProvider" -> false,
-              "lettings"-> false),
+              "socialHousingProvider" -> false),
         "ampServicesCarriedOut" -> Json.obj(
           "artGallery" -> true,
           "auctionHouse" -> true,

--- a/test/models/des/businessActivities/EabServicesSpec.scala
+++ b/test/models/des/businessActivities/EabServicesSpec.scala
@@ -19,6 +19,7 @@ package models.des.businessActivities
 import org.scalatestplus.play.PlaySpec
 
 class EabServicesSpec extends PlaySpec {
+
   "EabServices " should {
     "Be convertable from front end Estate agent business services" in {
       val from = {
@@ -26,7 +27,18 @@ class EabServicesSpec extends PlaySpec {
         EstateAgentBusiness(services = Some(Services(Set(BusinessTransfer, Development, Commercial))))
       }
 
-      val expected = Some(models.des.businessactivities.EabServices(false, true, false, false, true, false, false, true, false))
+      val expected = Some(models.des.businessactivities.EabServices(false, true, false, false, true, false, false, true, false, None))
+
+      models.des.businessactivities.EabServices.convert(Some(from)) must be (expected)
+    }
+
+    "Be convertable from front end Estate agent business services when none" in {
+      val from = {
+        import models.fe.estateagentbusiness._
+        EstateAgentBusiness(services = Some(Services(Set())))
+      }
+
+      val expected = Some(models.des.businessactivities.EabServices(false, false, false, false, false, false, false, false, false, None))
 
       models.des.businessactivities.EabServices.convert(Some(from)) must be (expected)
     }

--- a/test/models/des/estateagentbusiness/LettingAgentsSpec.scala
+++ b/test/models/des/estateagentbusiness/LettingAgentsSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.des.estateagentbusiness
+
+import models.fe.estateagentbusiness._
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.Json
+
+class LettingAgentsSpec extends PlaySpec {
+  "LettingAgents" must {
+
+    val services = Services(Set(Residential, Commercial, Auction))
+    val redressSchemeOther = Other("test")
+
+    val lettingAgentModel = LettingAgents(Some(true))
+    val lettingAgentModel2 = LettingAgents(Some(false))
+
+    val eab = EstateAgentBusiness(Some(services),Some(redressSchemeOther), None, None, Some(ClientMoneyProtectionSchemeYes))
+    val eab1 = EstateAgentBusiness(Some(services),Some(RedressSchemedNo), None, None, Some(ClientMoneyProtectionSchemeNo))
+    val eab2 = EstateAgentBusiness(Some(services),None, None, None)
+
+    "serialise LettingAgents model true" in {
+      LettingAgents.format.writes(lettingAgentModel) must be(Json.obj("clientMoneyProtection"->true))
+    }
+
+    "serialise LettingAgents model false" in {
+      LettingAgents.format.writes(lettingAgentModel2) must be(Json.obj("clientMoneyProtection"->false))
+    }
+
+    "successfully convert frontend eab to des LettingAgents model" in {
+      LettingAgents.conv(Some(eab)) must be(Some(LettingAgents(Some(true))))
+      LettingAgents.conv(Some(eab1)) must be(Some(LettingAgents(Some(false))))
+      LettingAgents.conv(Some(eab2)) must be(None)
+      LettingAgents.conv(None) must be(None)
+
+    }
+  }
+
+}

--- a/test/models/des/estateagentbusiness/LettingAgentsSpec.scala
+++ b/test/models/des/estateagentbusiness/LettingAgentsSpec.scala
@@ -23,13 +23,12 @@ import play.api.libs.json.Json
 class LettingAgentsSpec extends PlaySpec {
   "LettingAgents" must {
 
-    val services = Services(Set(Residential, Commercial, Auction))
+    val services           = Services(Set(Residential, Commercial, Auction))
     val redressSchemeOther = Other("test")
-
-    val lettingAgentModel = LettingAgents(Some(true))
+    val lettingAgentModel  = LettingAgents(Some(true))
     val lettingAgentModel2 = LettingAgents(Some(false))
 
-    val eab = EstateAgentBusiness(Some(services),Some(redressSchemeOther), None, None, Some(ClientMoneyProtectionSchemeYes))
+    val eab  = EstateAgentBusiness(Some(services),Some(redressSchemeOther), None, None, Some(ClientMoneyProtectionSchemeYes))
     val eab1 = EstateAgentBusiness(Some(services),Some(RedressSchemedNo), None, None, Some(ClientMoneyProtectionSchemeNo))
     val eab2 = EstateAgentBusiness(Some(services),None, None, None)
 
@@ -42,10 +41,10 @@ class LettingAgentsSpec extends PlaySpec {
     }
 
     "successfully convert frontend eab to des LettingAgents model" in {
-      LettingAgents.conv(Some(eab)) must be(Some(LettingAgents(Some(true))))
+      LettingAgents.conv(Some(eab))  must be(Some(LettingAgents(Some(true))))
       LettingAgents.conv(Some(eab1)) must be(Some(LettingAgents(Some(false))))
       LettingAgents.conv(Some(eab2)) must be(None)
-      LettingAgents.conv(None) must be(None)
+      LettingAgents.conv(None)       must be(None)
 
     }
   }

--- a/test/models/fe/AmendVariationResponseSpec.scala
+++ b/test/models/fe/AmendVariationResponseSpec.scala
@@ -135,6 +135,7 @@ class AmendVariationResponseSpec extends PlaySpec with OneAppPerSuite with Mocki
       eabResdEstAgncy = None,
       responsiblePersons = None,
       amp = None,
+      lettingAgents = None,
       extraFields = ExtraFields(
         declaration = Declaration(true),
         filingIndividual = AboutYouRelease7(None, true, None, None),

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpec.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.fe.estateagentbusiness
+
+import models.des.DesConstants
+import models.des.businessactivities.BusinessActivities
+import models.des.estateagentbusiness.{EabAll, LettingAgents}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json._
+
+class ClientMoneyProtectionSchemeSpec extends PlaySpec with MockitoSugar with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application = {
+    GuiceApplicationBuilder().configure(Map("microservice.services.feature-toggle.phase3-release2-la" -> false)).build()
+  }
+
+  "phase 3 toggle off" must {
+
+    "return none given no model and carry out Eab" in {
+      val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
+      ClientMoneyProtectionScheme.conv(view) must be(None)
+    }
+  }
+}
+

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpec.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpec.scala
@@ -20,17 +20,13 @@ import models.des.DesConstants
 import models.des.businessactivities.BusinessActivities
 import models.des.estateagentbusiness.{EabAll, LettingAgents}
 import org.scalatest.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json._
 
-class ClientMoneyProtectionSchemeSpec extends PlaySpec with MockitoSugar with GuiceOneAppPerSuite {
-
-  override def fakeApplication(): Application = {
-    GuiceApplicationBuilder().configure(Map("microservice.services.feature-toggle.phase3-release2-la" -> false)).build()
-  }
+class ClientMoneyProtectionSchemeSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
 
   "phase 3 toggle off" must {
 

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpec.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpec.scala
@@ -30,7 +30,7 @@ class ClientMoneyProtectionSchemeSpec extends PlaySpec with MockitoSugar with On
 
   "phase 3 toggle off" must {
 
-    "return none given no model and carry out Eab" in {
+    "return none given no model" in {
       val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
       ClientMoneyProtectionScheme.conv(view) must be(None)
     }

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.fe.estateagentbusiness
+
+import models.des.DesConstants
+import models.des.businessactivities.BusinessActivities
+import models.des.estateagentbusiness.{EabAll, LettingAgents}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json._
+
+class ClientMoneyProtectionSchemeSpecPhase3 extends PlaySpec with MockitoSugar with GuiceOneAppPerSuite  {
+
+  override def fakeApplication(): Application = {
+    GuiceApplicationBuilder().configure(Map("microservice.services.feature-toggle.phase3-release2-la" -> true)).build()
+  }
+
+  "JSON validation" must {
+
+    "phase 3 toggle" must {
+
+      "successfully validate given an enum value" in {
+
+        Json.fromJson[ClientMoneyProtectionScheme](Json.obj("clientMoneyProtection" -> false)) must
+          be(JsSuccess(ClientMoneyProtectionSchemeNo))
+      }
+
+      "successfully validate given an `Yes` value" in {
+
+        val json = Json.obj("clientMoneyProtection" -> true)
+
+        Json.fromJson[ClientMoneyProtectionScheme](json) must
+          be(JsSuccess(ClientMoneyProtectionSchemeYes))
+      }
+
+      "write the correct value" in {
+
+        Json.toJson(ClientMoneyProtectionSchemeNo) must
+          be(Json.obj("clientMoneyProtection" -> false))
+
+        Json.toJson(ClientMoneyProtectionSchemeYes) must
+          be(Json.obj("clientMoneyProtection" -> true))
+      }
+
+      "convert ClientMoneyProtectionScheme des model to frontend model with yes and given string" in {
+
+        val des = LettingAgents(Some(true))
+        val view = DesConstants.SubscriptionViewModel.copy(lettingAgents = Some(des))
+        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeYes))
+      }
+
+      "convert ClientMoneyProtectionScheme des model to frontend model no selected" in {
+
+        val des = EabAll(
+          estateAgencyActProhibition = true,
+          estAgncActProhibProvideDetails = Some("test"),
+          false,
+          None
+        )
+        val view = DesConstants.SubscriptionViewModel.copy(eabAll = Some(des))
+        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
+      }
+
+      "return no given no model and carry out Eab" in {
+
+        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
+        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
+      }
+
+      "return none given no model" in {
+
+        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None, businessActivities = BusinessActivities())
+        ClientMoneyProtectionScheme.conv(view) must be(None)
+      }
+    }
+  }
+}
+
+

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
@@ -14,99 +14,94 @@
  * limitations under the License.
  */
 
-///*
-// * Copyright 2020 HM Revenue & Customs
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//
-//package models.fe.estateagentbusiness
-//
-//import models.des.DesConstants
-//import models.des.businessactivities.BusinessActivities
-//import models.des.estateagentbusiness.{EabAll, LettingAgents}
-//import org.scalatest.mockito.MockitoSugar
-//import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-//import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
-//import play.api.Application
-//import play.api.inject.guice.GuiceApplicationBuilder
-//import play.api.libs.json._
-//
-//class ClientMoneyProtectionSchemeSpecPhase3 extends PlaySpec with MockitoSugar with GuiceOneAppPerSuite  {
-//
-//  override def fakeApplication(): Application = {
-//    GuiceApplicationBuilder().configure(Map("microservice.services.feature-toggle.phase3-release2-la" -> true)).build()
-//  }
-//
-//  "JSON validation" must {
-//
-//    "phase 3 toggle" must {
-//
-//      "successfully validate given an enum value" in {
-//
-//        Json.fromJson[ClientMoneyProtectionScheme](Json.obj("clientMoneyProtection" -> false)) must
-//          be(JsSuccess(ClientMoneyProtectionSchemeNo))
-//      }
-//
-//      "successfully validate given an `Yes` value" in {
-//
-//        val json = Json.obj("clientMoneyProtection" -> true)
-//
-//        Json.fromJson[ClientMoneyProtectionScheme](json) must
-//          be(JsSuccess(ClientMoneyProtectionSchemeYes))
-//      }
-//
-//      "write the correct value" in {
-//
-//        Json.toJson(ClientMoneyProtectionSchemeNo) must
-//          be(Json.obj("clientMoneyProtection" -> false))
-//
-//        Json.toJson(ClientMoneyProtectionSchemeYes) must
-//          be(Json.obj("clientMoneyProtection" -> true))
-//      }
-//
-//      "convert ClientMoneyProtectionScheme des model to frontend model with yes and given string" in {
-//
-//        val des = LettingAgents(Some(true))
-//        val view = DesConstants.SubscriptionViewModel.copy(lettingAgents = Some(des))
-//        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeYes))
-//      }
-//
-//      "convert ClientMoneyProtectionScheme des model to frontend model no selected" in {
-//
-//        val des = EabAll(
-//          estateAgencyActProhibition = true,
-//          estAgncActProhibProvideDetails = Some("test"),
-//          false,
-//          None
-//        )
-//        val view = DesConstants.SubscriptionViewModel.copy(eabAll = Some(des))
-//        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
-//      }
-//
-//      "return no given no model and carry out Eab" in {
-//
-//        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
-//        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
-//      }
-//
-//      "return none given no model" in {
-//
-//        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None, businessActivities = BusinessActivities())
-//        ClientMoneyProtectionScheme.conv(view) must be(None)
-//      }
-//    }
-//  }
-//}
-//
-//
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.fe.estateagentbusiness
+
+import models.des.DesConstants
+import models.des.businessactivities.BusinessActivities
+import models.des.estateagentbusiness.{EabAll, LettingAgents}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import org.scalatestplus.play.{PlaySpec}
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json._
+
+class ClientMoneyProtectionSchemeSpecPhase3 extends PlaySpec with MockitoSugar with GuiceOneAppPerTest  {
+
+  override def fakeApplication(): Application = {
+    GuiceApplicationBuilder().configure(Map("microservice.services.feature-toggle.phase3-release2-la" -> true)).build()
+  }
+
+  "JSON validation" must {
+
+    "phase 3 toggle" must {
+
+      "successfully validate given an enum value" in {
+
+        Json.fromJson[ClientMoneyProtectionScheme](Json.obj("clientMoneyProtection" -> false)) must
+          be(JsSuccess(ClientMoneyProtectionSchemeNo))
+      }
+
+      "successfully validate given an `Yes` value" in {
+
+        val json = Json.obj("clientMoneyProtection" -> true)
+
+        Json.fromJson[ClientMoneyProtectionScheme](json) must
+          be(JsSuccess(ClientMoneyProtectionSchemeYes))
+      }
+
+      "write the correct value" in {
+
+        Json.toJson(ClientMoneyProtectionSchemeNo) must
+          be(Json.obj("clientMoneyProtection" -> false))
+
+        Json.toJson(ClientMoneyProtectionSchemeYes) must
+          be(Json.obj("clientMoneyProtection" -> true))
+      }
+
+      "convert ClientMoneyProtectionScheme des model to frontend model with yes" in {
+
+        val des = LettingAgents(Some(true))
+        val view = DesConstants.SubscriptionViewModel.copy(lettingAgents = Some(des))
+        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeYes))
+      }
+
+      "convert ClientMoneyProtectionScheme des model to frontend model with no" in {
+
+        val des = LettingAgents(Some(false))
+        val view = DesConstants.SubscriptionViewModel.copy(lettingAgents = Some(des))
+        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
+      }
+
+      "return none given no model and carry out Eab" in {
+
+        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
+        ClientMoneyProtectionScheme.conv(view) must be(None)
+      }
+
+      "return none given no model" in {
+
+        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None, businessActivities = BusinessActivities())
+        ClientMoneyProtectionScheme.conv(view) must be(None)
+      }
+    }
+  }
+}
+
+

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2020 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package models.fe.estateagentbusiness
 
 import models.des.DesConstants

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
@@ -73,13 +73,23 @@ class ClientMoneyProtectionSchemeSpecPhase3 extends PlaySpec with MockitoSugar w
         ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
       }
 
-      "return none given no model and carry out Eab" in {
+      "convert ClientMoneyProtectionScheme des model to frontend model with lettings in eab but no letting agent" in {
+
+        val view = DesConstants.SubscriptionViewModel.copy(
+          lettingAgents = None,
+          businessActivities = DesConstants.testBusinessActivitiesLA
+        )
+
+        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
+      }
+
+      "return none given no model and no Eab" in {
 
         val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
         ClientMoneyProtectionScheme.conv(view) must be(None)
       }
 
-      "return none given no model" in {
+      "return none given no activities" in {
 
         val view = DesConstants.SubscriptionViewModel.copy(eabAll = None, businessActivities = BusinessActivities())
         ClientMoneyProtectionScheme.conv(view) must be(None)

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
@@ -14,83 +14,99 @@
  * limitations under the License.
  */
 
-package models.fe.estateagentbusiness
-
-import models.des.DesConstants
-import models.des.businessactivities.BusinessActivities
-import models.des.estateagentbusiness.{EabAll, LettingAgents}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json._
-
-class ClientMoneyProtectionSchemeSpecPhase3 extends PlaySpec with MockitoSugar with GuiceOneAppPerSuite  {
-
-  override def fakeApplication(): Application = {
-    GuiceApplicationBuilder().configure(Map("microservice.services.feature-toggle.phase3-release2-la" -> true)).build()
-  }
-
-  "JSON validation" must {
-
-    "phase 3 toggle" must {
-
-      "successfully validate given an enum value" in {
-
-        Json.fromJson[ClientMoneyProtectionScheme](Json.obj("clientMoneyProtection" -> false)) must
-          be(JsSuccess(ClientMoneyProtectionSchemeNo))
-      }
-
-      "successfully validate given an `Yes` value" in {
-
-        val json = Json.obj("clientMoneyProtection" -> true)
-
-        Json.fromJson[ClientMoneyProtectionScheme](json) must
-          be(JsSuccess(ClientMoneyProtectionSchemeYes))
-      }
-
-      "write the correct value" in {
-
-        Json.toJson(ClientMoneyProtectionSchemeNo) must
-          be(Json.obj("clientMoneyProtection" -> false))
-
-        Json.toJson(ClientMoneyProtectionSchemeYes) must
-          be(Json.obj("clientMoneyProtection" -> true))
-      }
-
-      "convert ClientMoneyProtectionScheme des model to frontend model with yes and given string" in {
-
-        val des = LettingAgents(Some(true))
-        val view = DesConstants.SubscriptionViewModel.copy(lettingAgents = Some(des))
-        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeYes))
-      }
-
-      "convert ClientMoneyProtectionScheme des model to frontend model no selected" in {
-
-        val des = EabAll(
-          estateAgencyActProhibition = true,
-          estAgncActProhibProvideDetails = Some("test"),
-          false,
-          None
-        )
-        val view = DesConstants.SubscriptionViewModel.copy(eabAll = Some(des))
-        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
-      }
-
-      "return no given no model and carry out Eab" in {
-
-        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
-        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
-      }
-
-      "return none given no model" in {
-
-        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None, businessActivities = BusinessActivities())
-        ClientMoneyProtectionScheme.conv(view) must be(None)
-      }
-    }
-  }
-}
-
-
+///*
+// * Copyright 2020 HM Revenue & Customs
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package models.fe.estateagentbusiness
+//
+//import models.des.DesConstants
+//import models.des.businessactivities.BusinessActivities
+//import models.des.estateagentbusiness.{EabAll, LettingAgents}
+//import org.scalatest.mockito.MockitoSugar
+//import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+//import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
+//import play.api.Application
+//import play.api.inject.guice.GuiceApplicationBuilder
+//import play.api.libs.json._
+//
+//class ClientMoneyProtectionSchemeSpecPhase3 extends PlaySpec with MockitoSugar with GuiceOneAppPerSuite  {
+//
+//  override def fakeApplication(): Application = {
+//    GuiceApplicationBuilder().configure(Map("microservice.services.feature-toggle.phase3-release2-la" -> true)).build()
+//  }
+//
+//  "JSON validation" must {
+//
+//    "phase 3 toggle" must {
+//
+//      "successfully validate given an enum value" in {
+//
+//        Json.fromJson[ClientMoneyProtectionScheme](Json.obj("clientMoneyProtection" -> false)) must
+//          be(JsSuccess(ClientMoneyProtectionSchemeNo))
+//      }
+//
+//      "successfully validate given an `Yes` value" in {
+//
+//        val json = Json.obj("clientMoneyProtection" -> true)
+//
+//        Json.fromJson[ClientMoneyProtectionScheme](json) must
+//          be(JsSuccess(ClientMoneyProtectionSchemeYes))
+//      }
+//
+//      "write the correct value" in {
+//
+//        Json.toJson(ClientMoneyProtectionSchemeNo) must
+//          be(Json.obj("clientMoneyProtection" -> false))
+//
+//        Json.toJson(ClientMoneyProtectionSchemeYes) must
+//          be(Json.obj("clientMoneyProtection" -> true))
+//      }
+//
+//      "convert ClientMoneyProtectionScheme des model to frontend model with yes and given string" in {
+//
+//        val des = LettingAgents(Some(true))
+//        val view = DesConstants.SubscriptionViewModel.copy(lettingAgents = Some(des))
+//        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeYes))
+//      }
+//
+//      "convert ClientMoneyProtectionScheme des model to frontend model no selected" in {
+//
+//        val des = EabAll(
+//          estateAgencyActProhibition = true,
+//          estAgncActProhibProvideDetails = Some("test"),
+//          false,
+//          None
+//        )
+//        val view = DesConstants.SubscriptionViewModel.copy(eabAll = Some(des))
+//        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
+//      }
+//
+//      "return no given no model and carry out Eab" in {
+//
+//        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None)
+//        ClientMoneyProtectionScheme.conv(view) must be(Some(ClientMoneyProtectionSchemeNo))
+//      }
+//
+//      "return none given no model" in {
+//
+//        val view = DesConstants.SubscriptionViewModel.copy(eabAll = None, businessActivities = BusinessActivities())
+//        ClientMoneyProtectionScheme.conv(view) must be(None)
+//      }
+//    }
+//  }
+//}
+//
+//

--- a/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
+++ b/test/models/fe/estateagentbusiness/ClientMoneyProtectionSchemeSpecPhase3.scala
@@ -18,7 +18,7 @@ package models.fe.estateagentbusiness
 
 import models.des.DesConstants
 import models.des.businessactivities.BusinessActivities
-import models.des.estateagentbusiness.{EabAll, LettingAgents}
+import models.des.estateagentbusiness.{LettingAgents}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import org.scalatestplus.play.{PlaySpec}

--- a/test/models/fe/estateagentbusiness/EstateAgentBusinessSpec.scala
+++ b/test/models/fe/estateagentbusiness/EstateAgentBusinessSpec.scala
@@ -18,10 +18,10 @@ package models.fe.estateagentbusiness
 
 import models.des.DesConstants
 import org.scalatest.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.Json
 
-class EstateAgentBusinessSpec extends PlaySpec with MockitoSugar {
+class EstateAgentBusinessSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
 
   val services = Services(Set(Residential, Commercial, Auction))
   val professionalBody = ProfessionalBodyYes("details")

--- a/test/models/fe/estateagentbusiness/PenalisedUnderEstateAgentsActSpec.scala
+++ b/test/models/fe/estateagentbusiness/PenalisedUnderEstateAgentsActSpec.scala
@@ -20,12 +20,12 @@ import models.des.businessactivities.BusinessActivities
 import models.des.{DesConstants, SubscriptionView}
 import models.des.estateagentbusiness.EabAll
 import org.scalatest.mockito.MockitoSugar
-import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{JsError, JsPath, JsSuccess, Json, JsonValidationError}
 
 
-class PenalisedUnderEstateAgentsActSpec extends PlaySpec with MockitoSugar {
+class PenalisedUnderEstateAgentsActSpec extends PlaySpec with MockitoSugar with OneAppPerSuite {
   "JSON validation" must {
 
     "successfully validate given an enum value" in {

--- a/test/models/fe/hvd/LinkedCashPaymentsSpec.scala
+++ b/test/models/fe/hvd/LinkedCashPaymentsSpec.scala
@@ -18,10 +18,10 @@ package models.fe.hvd
 
 import models.des.DesConstants
 import models.des.hvd.{HvdFromUnseenCustDetails, ReceiptMethods, Hvd => DesHvd}
-import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.{OneAppPerSuite, PlaySpec}
 import play.api.libs.json.{JsPath, JsSuccess}
 
-class LinkedCashPaymentsSpec extends PlaySpec {
+class LinkedCashPaymentsSpec extends PlaySpec with OneAppPerSuite {
 
   "LinkedCashPayments" should {
 

--- a/test/models/fe/tcsp/TcspSpec.scala
+++ b/test/models/fe/tcsp/TcspSpec.scala
@@ -205,6 +205,7 @@ class TcspSpec extends PlaySpec with MockitoSugar with TcspValues {
       Some(DesConstants.testEabResdEstAgncy),
       Some(DesConstants.testResponsiblePersons),
       Some(DesConstants.testAmp),
+      None,
       DesConstants.extraFields
     )
     Tcsp.conv(SubscriptionViewModel) must
@@ -240,6 +241,7 @@ class TcspSpec extends PlaySpec with MockitoSugar with TcspValues {
       Some(DesConstants.testEabResdEstAgncy),
       Some(DesConstants.testResponsiblePersons),
       Some(DesConstants.testAmp),
+      None,
       DesConstants.extraFields
     )
     Tcsp.conv(SubscriptionViewModel) must

--- a/test/utils/ChangeIndicatorHelperSpec.scala
+++ b/test/utils/ChangeIndicatorHelperSpec.scala
@@ -18,7 +18,7 @@ package utils
 import models.des.amp.Amp
 import models.des.asp.Asp
 import models.des.businessactivities.{AmpServices, BusinessActivities, MlrActivitiesAppliedFor}
-import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy}
+import models.des.estateagentbusiness.{EabAll, EabResdEstAgncy, LettingAgents}
 import models.des.hvd.Hvd
 import models.des.msb.{MoneyServiceBusiness, MsbAllDetails}
 import models.des.tcsp.{TcspAll, TcspTrustCompFormationAgt}
@@ -334,6 +334,7 @@ class ChangeIndicatorHelperSpec extends AmlsBaseSpec with ChangeIndicatorHelper 
       "eab" when {
         val eabSection = mock[EabAll]
         val eabResdEstAgncy = mock[EabResdEstAgncy]
+        val eabLettingAgents = mock[LettingAgents]
         val fullEabResdEstAgncy = eabResdEstAgncy.copy(regWithRedressScheme = true, whichRedressScheme = Some("foo"), None)
 
         "user does not have eab" when {
@@ -368,6 +369,15 @@ class ChangeIndicatorHelperSpec extends AmlsBaseSpec with ChangeIndicatorHelper 
 
             "set tcsp change indicator" in {
               when(api6.eabResdEstAgncy) thenReturn Some(updatedEabResdEstAgncy)
+              eabChangedIndicator(api5, api6) mustBe (true)
+            }
+          }
+
+          "eab letting agents section has changed" must {
+            val updatedEabLettingAgent = eabLettingAgents.copy(clientMoneyProtection = Some(true))
+
+            "set tcsp change indicator" in {
+              when(api6.lettingAgents) thenReturn Some(updatedEabLettingAgent)
               eabChangedIndicator(api5, api6) mustBe (true)
             }
           }


### PR DESCRIPTION
Added feature toggle for phase 3 (LA).

Added Client Protection models and conversion logic for DES interactions.

The addition of Letting Agents took us over the tupple 22 issue within the AmenVariationRequest. This was handled by splitting the reads and writes in two and merging them together. As DES schemas govern the json keys we can't simply group tuples together. 

## Related / Dependant PRs?

https://github.com/hmrc/amls-frontend/pull/1388

Stubs branch: https://github.com/hmrc/amls-stub/tree/AMLS-5779-la

## How Has This Been Tested?

Unit, Local, toggled on, toggled off, regression when toggled off.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [x] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
