### PR TITLE
[SM][DLS-5877] Changes to Agent Details so that Some(false) is return…

### DIFF
--- a/app/models/des/tradingpremises/AgentDetails.scala
+++ b/app/models/des/tradingpremises/AgentDetails.scala
@@ -102,7 +102,7 @@ object AgentDetails {
     }
 
     val dateChangeFlag = requestType match {
-      case RequestType.Subscription => Some(false)
+      case RequestType.Amendment => Some(false)
       case _ => None
     }
 

--- a/app/models/des/tradingpremises/AgentDetails.scala
+++ b/app/models/des/tradingpremises/AgentDetails.scala
@@ -101,6 +101,11 @@ object AgentDetails {
       case _ => (None, None)
     }
 
+    val dateChangeFlag = requestType match {
+      case RequestType.Subscription => Some(false)
+      case _ => None
+    }
+
     AgentDetails(
       agentLegalEntity = tradingPremises.businessStructure.fold("")(x => x),
       companyRegNo = assignCompanyRegNo,
@@ -117,7 +122,7 @@ object AgentDetails {
       },
       agentPremises = tradingPremises,
       startDate,
-      None,
+      dateChangeFlag = dateChangeFlag,
       endDate,
       tradingPremises.status,
       tradingPremises.lineId,


### PR DESCRIPTION
…ed if it is a Subscription journey.

Signed-off-by: Sean Murray <sean.murray@digital.hmrc.gov.uk>

This change has been made because the DES API6 now requires the dateChangeflag, thus we return a Some(false). Since datechangeFLag is not present in other APIs ( e.g. API4 ) we still require that a None is returned in other journey types.
## Related / Dependant PRs?

<!--- List any related issues here -->

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
