### PR TITLE
DLS-5618 hmrc-mongo update

### DIFF
--- a/app/utils/ApiRetryHelper.scala
+++ b/app/utils/ApiRetryHelper.scala
@@ -22,7 +22,7 @@ import config.ApplicationConfig
 import exceptions.HttpStatusException
 
 import javax.inject._
-import play.api.{Logger, Logging}
+import play.api.Logging
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -47,7 +47,7 @@ class ApiRetryHelper @Inject()(val as: ActorSystem, appConfig: ApplicationConfig
         if ( e.status >= 500 && e.status < 600 && currentAttempt < maxAttempts) {
           val wait = Math.ceil(currentWait * waitFactor).toInt
           logger.warn(s"Failure, retrying after $wait ms")
-          after(wait.milliseconds, as.scheduler, ec, Future.successful(1)).flatMap { _ =>
+          after(wait.milliseconds, as.scheduler, ec, () => Future.successful(1)).flatMap { _ =>
             expBackOffHelper(currentAttempt + 1, wait.toInt, f)
           }
         } else {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,12 +12,12 @@ private object AppDependencies {
     "org.typelevel"       %% "cats"                       % "0.9.0",
     "com.eclipsesource"   %% "play-json-schema-validator" % "0.9.4",
     "de.flapdoodle.embed" %  "de.flapdoodle.embed.mongo"  % "2.2.0" % "test,it",
-    "com.beachape"        %% "enumeratum"                 % "1.6.1",
+    "com.beachape"        %% "enumeratum"                 % "1.7.0",
     "uk.gov.hmrc"         %% "bootstrap-backend-play-28"  % "5.12.0",
     "com.typesafe.play"   %% "play-json-joda"             % "2.7.4",
-    "com.github.kxbmap"   %% "configs"                    % "0.4.4",
-    "com.github.ghik"     %  "silencer-lib"               % "1.7.5" % Provided cross CrossVersion.full,
-    compilerPlugin("com.github.ghik" % "silencer-plugin"  % "1.7.5" cross CrossVersion.full)
+    "com.github.kxbmap"   %% "configs"                    % "0.6.1",
+    "com.github.ghik"     %  "silencer-lib"               % "1.7.11" % Provided cross CrossVersion.full,
+    compilerPlugin("com.github.ghik" % "silencer-plugin"  % "1.7.11" cross CrossVersion.full)
   )
 
   trait TestDependencies {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ private object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"         %% "simple-reactivemongo"       % "8.0.0-play-28",
+    "uk.gov.hmrc.mongo"   %% "hmrc-mongo-play-28"         % "0.73.0",
     "uk.gov.hmrc"         %% "mongo-caching"              % "7.0.0-play-28",
     "uk.gov.hmrc"         %% "domain"                     % "6.2.0-play-28",
     "org.typelevel"       %% "cats"                       % "0.9.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.4.0")
 addSbtPlugin("com.github.gseitz"  %  "sbt-release"            % "1.0.13")
-addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.8")
+addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.16")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-settings"           % "4.5.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.1.0")
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "1.8.1")


### PR DESCRIPTION
- Switches from simple-reactivemongo to hmrc-mongo
- Updates libraries to the next minor version (when possible)

