### PR TITLE
DDCYLS-2315

### DIFF
--- a/app/models/Fees.scala
+++ b/app/models/Fees.scala
@@ -18,7 +18,10 @@ package models
 
 import models.des.AmendVariationResponse
 import models.fe.SubscriptionResponse
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import play.custom.JsPathSupport._
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.LocalDateTime
 import java.time.ZoneOffset.UTC
@@ -93,5 +96,36 @@ object Fees {
       LocalDateTime.now(UTC))
   }
 
-  implicit val format: OFormat[Fees] = Json.format[Fees]
+  implicit lazy val reads: Reads[Fees] =
+    (
+      (__ \ "responseType").read[ResponseType] and
+        (__ \ "amlsReferenceNumber").read[String] and
+        (__ \ "registrationFee").read[BigDecimal] and
+        (__ \ "fpFee").readNullable[BigDecimal] and
+        (__ \ "premiseFee").read[BigDecimal] and
+        (__ \ "totalFees").read[BigDecimal] and
+        (__ \ "paymentReference").readNullable[String] and
+        (__ \ "difference").readNullable[BigDecimal] and
+        (__ \ "approvalCheckFeeRate").readNullable[BigDecimal] and
+        (__ \ "approvalCheckFee").readNullable[BigDecimal] and
+        (__ \ "createdAt").readLocalDateTime
+      ) (Fees.apply _)
+
+
+  implicit lazy val writes: OWrites[Fees] =
+    (
+      (__ \ "responseType").write[ResponseType] and
+        (__ \ "amlsReferenceNumber").write[String] and
+        (__ \ "registrationFee").write[BigDecimal] and
+        (__ \ "fpFee").writeNullable[BigDecimal] and
+        (__ \ "premiseFee").write[BigDecimal] and
+        (__ \ "totalFees").write[BigDecimal] and
+        (__ \ "paymentReference").writeNullable[String] and
+        (__ \ "difference").writeNullable[BigDecimal] and
+        (__ \ "approvalCheckFeeRate").writeNullable[BigDecimal] and
+        (__ \ "approvalCheckFee").writeNullable[BigDecimal] and
+        (__ \ "createdAt").write[LocalDateTime](MongoJavatimeFormats.localDateTimeWrites)
+      ) (unlift(Fees.unapply))
+
+  implicit val format: OFormat[Fees] = OFormat(reads, writes)
 }

--- a/app/play/custom/JsPathSupport.scala
+++ b/app/play/custom/JsPathSupport.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package play.custom
+
+import play.api.libs.json.{JsPath, Reads}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object JsPathSupport {
+  implicit class RichJsPath(path: JsPath) {
+
+    def readLocalDateTime: Reads[LocalDateTime] = {
+      Reads
+        .at[String](path \ "$date")
+        .map(dateTimeStr => LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+        .orElse {
+          Reads.at[String](path).map(dateTimeStr => LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+        }
+        .orElse {
+          Reads.at[LocalDateTime](path)(MongoJavatimeFormats.localDateTimeReads)
+        }
+    }
+  }
+}


### PR DESCRIPTION
It turns out that the created date & time for Fees was saved in an iso format like this:

2022-10-17T10:08:28.462Z

In order to be able to read this a custom date time formatter using DateTimeFormatter.ISO_OFFSET_DATE_TIME is needed as well as the rest of the reads to read the new format that the HMRC Mongo Library will save the time under.