### PR TITLE
DDCYLS-3711 Fixed JSON reads to support legacy date Strings

### DIFF
--- a/app/play/custom/JsPathSupport.scala
+++ b/app/play/custom/JsPathSupport.scala
@@ -28,7 +28,7 @@ object JsPathSupport {
   final val readLocalDateTime: Reads[LocalDateTime] = {
     (__ \ "$date").read[String].map(dateTimeStr => LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME))
       .orElse {
-        Reads.at[String](__).map(dateTime => Instant.ofEpochMilli(dateTime.toLong).atZone(ZoneOffset.UTC).toLocalDateTime)
+        Reads.at[String](__).map(LocalDateTime.parse)
       }
       .orElse {
         Reads.at[String](__ \ "$date" \ "$numberLong").map(dateTime => Instant.ofEpochMilli(dateTime.toLong).atZone(ZoneOffset.UTC).toLocalDateTime)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,13 +19,6 @@ include "backend.conf"
 
 appName = amls
 
-# Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
-# A metric filter must be provided
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-
-# Provides an implementation and configures all filters required by a Platform backend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
-
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,12 +1,11 @@
-import sbt._
+import sbt.*
 
 private object AppDependencies {
-  import play.sbt.PlayImport._
-  import play.core.PlayVersion
+  import play.sbt.PlayImport.*
 
   val bootstrapVersion = "7.19.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc.mongo"    %% "hmrc-mongo-play-28"         % "1.3.0",
     "org.typelevel"        %% "cats-core"                  % "2.9.0",
@@ -19,8 +18,8 @@ private object AppDependencies {
   )
 
   trait TestDependencies {
-    lazy val scope: String = "test"
-    lazy val test : Seq[ModuleID] = ???
+    val scope: String = "test"
+    val test : Seq[ModuleID]
   }
 
   private val scalatestVersion = "3.2.15"
@@ -30,7 +29,7 @@ private object AppDependencies {
 
   object Test {
     def apply() = new TestDependencies {
-      override lazy val test = Seq(
+      override val test: Seq[sbt.ModuleID] = Seq(
         "org.mockito"             %% "mockito-scala"             % "1.17.12"                % scope,
         "org.scalatestplus"       %% "scalacheck-1-17"           % "3.2.15.0"               % scope,
         "uk.gov.hmrc"             %% "bootstrap-test-play-28"    % bootstrapVersion         % scope,
@@ -42,15 +41,14 @@ private object AppDependencies {
   object IntegrationTest {
     def apply() = new TestDependencies {
 
-      override lazy val scope: String = "it"
+      override val scope: String = "it"
 
-      override lazy val test = Seq(
+      override val test: Seq[sbt.ModuleID] = Seq(
         "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28" % "1.3.0"                  % scope,
         "uk.gov.hmrc"             %% "bootstrap-test-play-28"  % bootstrapVersion         % scope
-
       )
     }.test
   }
 
-  def apply() = compile ++ Test() ++ IntegrationTest()
+  def apply(): Seq[sbt.ModuleID] = compile ++ Test() ++ IntegrationTest()
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.14.0")
 addSbtPlugin("com.github.gseitz"  %  "sbt-release"            % "1.0.13")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.19")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.2.0")

--- a/test/play/custom/JsPathSupportSpec.scala
+++ b/test/play/custom/JsPathSupportSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package play.custom
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.{JsString, JsSuccess, Json, __}
+import play.custom.JsPathSupport.readLocalDateTime
+
+import java.time.LocalDateTime
+
+class JsPathSupportSpec extends AnyWordSpec with Matchers {
+
+  "readLocalDateTime" should {
+
+    "read a date String at the top level" in {
+      readLocalDateTime.reads(JsString("1970-01-23T18:27:17.851")) shouldBe
+        JsSuccess(LocalDateTime.parse("1970-01-23T18:27:17.851"), __)
+    }
+
+    "read a Date with ISO offset in the nested $date object" in {
+      readLocalDateTime.reads(Json.obj("$date" -> "1970-01-23T18:27:17.851Z")) shouldBe
+        JsSuccess(LocalDateTime.parse("1970-01-23T18:27:17.851"), __ \ "$date")
+    }
+
+    "read a Long in the nested $date -> $numberLong object" in {
+      readLocalDateTime.reads(Json.obj("$date" -> Json.obj("$numberLong" -> "1967237851"))) shouldBe
+        JsSuccess(LocalDateTime.parse("1970-01-23T18:27:17.851"), __ \ "$date" \ "$numberLong")
+    }
+  }
+}


### PR DESCRIPTION
Refer to the corresponding Jira ticket for my investigation notes for why I made this change.

The tl;dr is that we have JSON reads that is attempting to convert a String date to a Long. This affects older data that was stored in our database before April 2023. I've written unit tests so that going forward we have tests in place for both old (String) and new (Long / ISODate) formats.