### PR TITLE
DDCYLS-3712 Fix to PaymentRepository update logic

### DIFF
--- a/it/repositories/PaymentRepositorySpec.scala
+++ b/it/repositories/PaymentRepositorySpec.scala
@@ -11,18 +11,21 @@ import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext
 
-class PaymentRepositorySpec extends AnyFreeSpec with Matchers with DefaultPlayMongoRepositorySupport[Payment] with IntegrationPatience {
+class PaymentRepositorySpec extends AnyFreeSpec with Matchers with DefaultPlayMongoRepositorySupport[Payment]
+  with IntegrationPatience {
 
   implicit val executionContext: ExecutionContext = Helpers.stubControllerComponents().executionContext
   override lazy val repository = new PaymentRepository(mongoComponent)
 
+  val exampleDate: LocalDateTime = LocalDateTime.parse("2023-02-21T10:08:12")
+  val payment: Payment = Payment(
+    "006d7f4db2700ab06ad90e1dfacfdae8", "XZML00000219894", "XCML00000571981", "Xbowpvotcr",
+    Some("description"), 10000, Sent, exampleDate, Some(false), Some(exampleDate)
+  )
+
   "Payment Repository" - {
 
     "must insert a payment" in {
-      // Given
-      val payment = Payment("9f8bbb4adbfaca8991005f9a1a291bef", "XQML00000315655", "XJML00000265458", "XtnaqFrm5x", None,
-        1000, Cancelled, LocalDateTime.parse("2023-02-21T10:04:54"), None, None)
-
       // When
       val insertedPayment = repository.insert(payment).futureValue
 
@@ -31,21 +34,153 @@ class PaymentRepositorySpec extends AnyFreeSpec with Matchers with DefaultPlayMo
       repository.collection.countDocuments().head().futureValue mustEqual 1
     }
 
-    "must update a payment" in {
-      // Given
-      val payment = Payment("006d7f4db2700ab06ad90e1dfacfdae8", "XZML00000219894", "XCML00000571981", "Xbowpvotcr", None,
-        10000, Sent, LocalDateTime.parse("2023-02-21T10:08:12"), None, None)
+    "must update a payment" - {
 
-      repository.insert(payment).futureValue
+      "when the AMLS ref no has changed" in {
+        // Given
+        repository.insert(payment).futureValue
 
-      // When
-      val updateResult = repository.update(Payment("006d7f4db2700ab06ad90e1dfacfdae8", "XZML00000219894", "XCML00000571981", "Xbowpvotcr", None,
-        10000, Successful, LocalDateTime.parse("2023-02-21T10:08:12"), None, Some(LocalDateTime.parse("2023-02-22T12:09:18")))).futureValue
+        // When
+        val updateResult = repository.update(payment.copy(amlsRefNo = "X")).futureValue
 
-      // Then
-      updateResult.wasAcknowledged() mustEqual true
-      updateResult.getMatchedCount mustEqual 1
-      updateResult.getModifiedCount mustEqual 1
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the safe ID has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(safeId = "X")).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the payment ref no has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(reference = "X")).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the description has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(description = Some("X"))).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the payment amount has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(amountInPence = 1)).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the status has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(status = Successful)).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the createdAt date has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(createdAt = exampleDate.plusDays(1))).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the BACS flag has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(isBacs = Some(true))).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+
+      "when the updatedAt date has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(updatedAt = Some(exampleDate.plusDays(1)))).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 1
+      }
+    }
+
+    "must not update a payment" - {
+
+      "when nothing has changed" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 1
+        updateResult.getModifiedCount mustEqual 0
+      }
+
+      "when no matching payment was found" in {
+        // Given
+        repository.insert(payment).futureValue
+
+        // When
+        val updateResult = repository.update(payment.copy(_id = "X")).futureValue
+
+        // Then
+        updateResult.wasAcknowledged() mustEqual true
+        updateResult.getMatchedCount mustEqual 0
+        updateResult.getModifiedCount mustEqual 0
+      }
     }
 
     "must find latest payment by AMLS reference" in {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 private object AppDependencies {
   import play.sbt.PlayImport.*
 
-  val bootstrapVersion = "7.19.0"
+  val bootstrapVersion = "7.22.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
@@ -22,13 +22,8 @@ private object AppDependencies {
     val test : Seq[ModuleID]
   }
 
-  private val scalatestVersion = "3.2.15"
-  private val scalatestPlusPlayVersion = "5.1.0"
-  private val pegdownVersion = "1.6.0"
-  private val scalacheckVersion = "1.17.0"
-
   object Test {
-    def apply() = new TestDependencies {
+    def apply(): Seq[sbt.ModuleID] = new TestDependencies {
       override val test: Seq[sbt.ModuleID] = Seq(
         "org.mockito"             %% "mockito-scala"             % "1.17.12"                % scope,
         "org.scalatestplus"       %% "scalacheck-1-17"           % "3.2.15.0"               % scope,
@@ -39,7 +34,7 @@ private object AppDependencies {
   }
 
   object IntegrationTest {
-    def apply() = new TestDependencies {
+    def apply(): Seq[sbt.ModuleID] = new TestDependencies {
 
       override val scope: String = "it"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.14.0")
 addSbtPlugin("com.github.gseitz"  %  "sbt-release"            % "1.0.13")
-addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.19")
+addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.20")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.2.0")
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "2.0.5")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "1.0.0")


### PR DESCRIPTION
See Jira ticket comments for investigation comments that explain why the change was made. The tl;dr is that the optional fields in the Payment model had some bad logic around them which meant they were not able to be updated in mongo.